### PR TITLE
Product getById結合テスト追加（存在しないIDを指定した際期待通り404を返すこと

### DIFF
--- a/src/test/java/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/UserRestApiIntegrationTest.java
@@ -2,8 +2,11 @@ package integrationtest;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.spring.api.DBRider;
+import com.jayway.jsonpath.JsonPath;
 import com.raisetech.inventoryapi.Work09Application;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +19,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest(classes = Work09Application.class)
 @AutoConfigureMockMvc
@@ -67,5 +72,19 @@ public class UserRestApiIntegrationTest {
                 , response, JSONCompareMode.STRICT);
 
     }
+    
+    @DataSet(value = "products.yml")
+    @Transactional
+    @ParameterizedTest
+    @ValueSource(ints = {0, 100})
+    void 存在しないIDを指定した際期待通り404を返すこと(int productId) throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/products/" + productId))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
+        assertEquals("404", JsonPath.read(response, "$.status"));
+        assertEquals("/products/" + productId, JsonPath.read(response, "$.path"));
+        assertEquals("Not Found", JsonPath.read(response, "$.error"));
+        assertEquals("Product ID:" + productId + " does not exist", JsonPath.read(response, "$.message"));
+    }
 }


### PR DESCRIPTION
# 概要
2bc7dad6923f11db5e488fd57900ec0c8cb9dee6

存在しないIDを指定した際期待通り404を返すこと　テストケースを追加しました。

* IDが0と100のときのレスポンスが404であることの確認
* 〃のときのレスポンスの内容が合っているかの確認
* timestampはテスト都度変わってしまうので、Jsonpathでtimestamp以外の値が同じか確認しています