### PR TITLE
UserRestApiIntegrationTest:新規登録時201を返すことテストの実装

### DIFF
--- a/src/test/java/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/UserRestApiIntegrationTest.java
@@ -76,8 +76,8 @@ public class UserRestApiIntegrationTest {
 
     }
 
-    @DataSet(value = "products.yml")
     @Transactional
+    @DataSet(value = "products.yml")
     @ParameterizedTest
     @ValueSource(ints = {0, 100})
     void 存在しないIDを指定した際期待通り404を返すこと(int productId) throws Exception {
@@ -115,21 +115,20 @@ public class UserRestApiIntegrationTest {
     @DataSet(value = "products.yml")
     @Transactional
     void 新規登録後DBにレコードが登録されていること() throws Exception {
-        Product request = new Product("Shaft");
+        Product request = new Product(3, "Shaft");
         ObjectMapper objectMapper = new ObjectMapper();
         String requestJson = objectMapper.writeValueAsString(request);
         mockMvc.perform(MockMvcRequestBuilders.post("/products")
                         .content(requestJson).contentType(MediaType.APPLICATION_JSON))
                 .andExpect(MockMvcResultMatchers.status().isCreated());
 
-
-        String response = mockMvc.perform(MockMvcRequestBuilders.get("/products/0"))
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/products/3"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
         JSONAssert.assertEquals("""
                         {
-                           "id":0,
+                           "id":3,
                            "name":"Shaft"
                         }
                         """

--- a/src/test/java/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/UserRestApiIntegrationTest.java
@@ -110,4 +110,30 @@ public class UserRestApiIntegrationTest {
                         """
                 , response, JSONCompareMode.STRICT);
     }
+
+    @Test
+    @DataSet(value = "products.yml")
+    @Transactional
+    void 新規登録後DBにレコードが登録されていること() throws Exception {
+        Product request = new Product("Shaft");
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestJson = objectMapper.writeValueAsString(request);
+        mockMvc.perform(MockMvcRequestBuilders.post("/products")
+                        .content(requestJson).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isCreated());
+
+
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/products/0"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                        {
+                           "id":0,
+                           "name":"Shaft"
+                        }
+                        """
+                , response, JSONCompareMode.STRICT);
+    }
+
 }


### PR DESCRIPTION
# createProduct 結合テストの実装
* 新規商品を登録でき201を返すこと　テストケースの実装（https://github.com/Kumagai6824/Inventory-API/commit/400766b4a18899d3d49af148cf5406a894620581)

まずは正常系のテストとして、201を返し、レスポンスのメッセージ内容が一致しているかのテストを実装しました。
異常系のテストは別途検討したいと考えています。
まずはこちらのご確認をお願いいたします。