### PR TITLE
新規登録時nullまたは空文字または31文字以上のリクエストの場合400を返すことテストの実装

### DIFF
--- a/src/test/java/com/raisetech/inventoryapi/CreateFormTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/CreateFormTest.java
@@ -45,7 +45,8 @@ class CreateFormTest {
 
     @Test
     public void nameが31文字以上のときにバリデーションエラーとなること() {
-        CreateForm createForm = new CreateForm("1234567890123456789012345678901");
+        String name = "Shaft";
+        CreateForm createForm = new CreateForm(name.repeat(6) + "1");
         Set<ConstraintViolation<CreateForm>> violations = validator.validate(createForm);
         assertThat(violations).hasSize(1);
         assertThat(violations)

--- a/src/test/java/com/raisetech/inventoryapi/CreateFormTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/CreateFormTest.java
@@ -1,0 +1,60 @@
+package com.raisetech.inventoryapi;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+class CreateFormTest {
+    private static Validator validator;
+
+    @BeforeAll
+    public static void setUpValidator() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    public void nameがnullのときにバリデーションエラーとなること() {
+        CreateForm createForm = new CreateForm(null);
+        Set<ConstraintViolation<CreateForm>> violations = validator.validate(createForm);
+        assertThat(violations).hasSize(2);
+        assertThat(violations)
+                .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                .containsExactlyInAnyOrder(tuple("name", "空白は許可されていません"), tuple("name", "null は許可されていません"));
+    }
+
+    @Test
+    public void nameが空文字のときにバリデーションエラーとなること() {
+        CreateForm createForm = new CreateForm("");
+        Set<ConstraintViolation<CreateForm>> violations = validator.validate(createForm);
+        assertThat(violations).hasSize(1);
+        assertThat(violations)
+                .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                .containsExactlyInAnyOrder(tuple("name", "空白は許可されていません"));
+    }
+
+    @Test
+    public void nameが31文字以上のときにバリデーションエラーとなること() {
+        CreateForm createForm = new CreateForm("1234567890123456789012345678901");
+        Set<ConstraintViolation<CreateForm>> violations = validator.validate(createForm);
+        assertThat(violations).hasSize(1);
+        assertThat(violations)
+                .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                .containsExactlyInAnyOrder(tuple("name", "0 から 30 の間のサイズにしてください"));
+    }
+
+    @Test
+    public void nameに値があるときバリデーションエラーとならないこと() {
+        CreateForm createForm = new CreateForm("Shaft");
+        Set<ConstraintViolation<CreateForm>> violations = validator.validate(createForm);
+        assertThat(violations).isEmpty();
+    }
+}

--- a/src/test/java/com/raisetech/inventoryapi/CreateFormTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/CreateFormTest.java
@@ -38,7 +38,7 @@ class CreateFormTest {
         assertThat(violations).hasSize(1);
         assertThat(violations)
                 .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
-                .containsExactlyInAnyOrder(tuple("name", "空白は許可されていません"));
+                .containsExactlyInAnyOrder(tuple("name", "must not be blank"));
     }
 
     @Test
@@ -48,7 +48,7 @@ class CreateFormTest {
         assertThat(violations).hasSize(1);
         assertThat(violations)
                 .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
-                .containsExactlyInAnyOrder(tuple("name", "0 から 30 の間のサイズにしてください"));
+                .containsExactlyInAnyOrder(tuple("name", "size must be between 0 and 30"));
     }
 
     @Test

--- a/src/test/java/com/raisetech/inventoryapi/CreateFormTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/CreateFormTest.java
@@ -28,7 +28,7 @@ class CreateFormTest {
         assertThat(violations).hasSize(2);
         assertThat(violations)
                 .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
-                .containsExactlyInAnyOrder(tuple("name", "空白は許可されていません"), tuple("name", "null は許可されていません"));
+                .containsExactlyInAnyOrder(tuple("name", "must not be blank"), tuple("name", "must not be null"));
     }
 
     @Test

--- a/src/test/java/com/raisetech/inventoryapi/CreateFormTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/CreateFormTest.java
@@ -7,6 +7,7 @@ import jakarta.validation.ValidatorFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -17,6 +18,7 @@ class CreateFormTest {
 
     @BeforeAll
     public static void setUpValidator() {
+        Locale.setDefault(Locale.JAPAN);
         ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
         validator = factory.getValidator();
     }
@@ -28,7 +30,7 @@ class CreateFormTest {
         assertThat(violations).hasSize(2);
         assertThat(violations)
                 .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
-                .containsExactlyInAnyOrder(tuple("name", "must not be blank"), tuple("name", "must not be null"));
+                .containsExactlyInAnyOrder(tuple("name", "空白は許可されていません"), tuple("name", "null は許可されていません"));
     }
 
     @Test
@@ -38,7 +40,7 @@ class CreateFormTest {
         assertThat(violations).hasSize(1);
         assertThat(violations)
                 .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
-                .containsExactlyInAnyOrder(tuple("name", "must not be blank"));
+                .containsExactlyInAnyOrder(tuple("name", "空白は許可されていません"));
     }
 
     @Test
@@ -48,7 +50,7 @@ class CreateFormTest {
         assertThat(violations).hasSize(1);
         assertThat(violations)
                 .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
-                .containsExactlyInAnyOrder(tuple("name", "size must be between 0 and 30"));
+                .containsExactlyInAnyOrder(tuple("name", "0 から 30 の間のサイズにしてください"));
     }
 
     @Test

--- a/src/test/java/com/raisetech/inventoryapi/ValidationApplicationTests.java
+++ b/src/test/java/com/raisetech/inventoryapi/ValidationApplicationTests.java
@@ -1,0 +1,12 @@
+package com.raisetech.inventoryapi;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ValidationApplicationTests {
+    @Test
+    void contextLoads() {
+    }
+}
+


### PR DESCRIPTION
# Integration テスト実装
6760b9b7621693ada5f59d1fd9cadc7e6031383c

nameにnull、空文字（半角）、31文字以上でリクエストした場合にバリデーションエラーでBad request 400を返すことのテストを実装しました。

# CreateForm テスト実装
929a1854d60b223b4e615116677951363b7daa41
特別講義のフォーム向けテストを参考に実装しました。
エラーメッセージはローカルでは日本語でパスした一方、github CIは落ちたので、英語へ変更したところCIパスしました。