### PR TITLE
updateProductのテスト実装

### DIFF
--- a/src/test/java/com/raisetech/inventoryapi/CreateFormTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/CreateFormTest.java
@@ -55,6 +55,14 @@ class CreateFormTest {
     }
 
     @Test
+    public void nameが30文字のときバリデーションエラーとならないこと() {
+        String name = "Shaft";
+        CreateForm createForm = new CreateForm(name.repeat(6));
+        Set<ConstraintViolation<CreateForm>> violations = validator.validate(createForm);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
     public void nameに値があるときバリデーションエラーとならないこと() {
         CreateForm createForm = new CreateForm("Shaft");
         Set<ConstraintViolation<CreateForm>> violations = validator.validate(createForm);

--- a/src/test/java/com/raisetech/inventoryapi/ProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/ProductServiceImplTest.java
@@ -69,4 +69,15 @@ class ProductServiceImplTest {
         productServiceImpl.updateProductById(id, renewedName);
         verify(productMapper, times(1)).updateProductById(id, renewedName);
     }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0})
+    public void 存在しない商品IDを指定して更新したときに期待通り例外を返すこと(Integer id) throws Exception {
+        String initialName = "Bolt";
+        String renewedName = "audience participation program";
+        when(productMapper.findById(id)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> productServiceImpl.updateProductById(id, renewedName))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("resource not found with id: " + id);
+    }
 }

--- a/src/test/java/com/raisetech/inventoryapi/ProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/ProductServiceImplTest.java
@@ -2,6 +2,8 @@ package com.raisetech.inventoryapi;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -56,5 +58,15 @@ class ProductServiceImplTest {
         productServiceImpl.createProduct(product);
         verify(productMapper, times(1)).createProduct(product);
 
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"1", "100"})
+    public void 商品IDを指定して更新したときに商品情報が更新されること(int id) throws Exception {
+        String initialName = "Bolt";
+        String renewedName = "audience participation program";
+        when(productMapper.findById(id)).thenReturn(Optional.of(new Product(id, initialName)));
+        productServiceImpl.updateProductById(id, renewedName);
+        verify(productMapper, times(1)).updateProductById(id, renewedName);
     }
 }

--- a/src/test/java/com/raisetech/inventoryapi/ProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/ProductServiceImplTest.java
@@ -64,7 +64,7 @@ class ProductServiceImplTest {
     @ValueSource(strings = {"1", "100"})
     public void 商品IDを指定して更新したときに商品情報が更新されること(int id) throws Exception {
         String initialName = "Bolt";
-        String renewedName = "audience participation program";
+        String renewedName = "Shaft";
         when(productMapper.findById(id)).thenReturn(Optional.of(new Product(id, initialName)));
         productServiceImpl.updateProductById(id, renewedName);
         verify(productMapper, times(1)).updateProductById(id, renewedName);
@@ -73,8 +73,7 @@ class ProductServiceImplTest {
     @ParameterizedTest
     @ValueSource(ints = {0})
     public void 存在しない商品IDを指定して更新したときに期待通り例外を返すこと(Integer id) throws Exception {
-        String initialName = "Bolt";
-        String renewedName = "audience participation program";
+        String renewedName = "Shaft";
         when(productMapper.findById(id)).thenReturn(Optional.empty());
         assertThatThrownBy(() -> productServiceImpl.updateProductById(id, renewedName))
                 .isInstanceOf(ResourceNotFoundException.class)

--- a/src/test/java/com/raisetech/inventoryapi/ProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/ProductServiceImplTest.java
@@ -61,7 +61,7 @@ class ProductServiceImplTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"1", "100"})
+    @ValueSource(ints = {1, 100})
     public void 商品IDを指定して更新したときに商品情報が更新されること(int id) throws Exception {
         String initialName = "Bolt";
         String renewedName = "Shaft";
@@ -72,7 +72,7 @@ class ProductServiceImplTest {
 
     @ParameterizedTest
     @ValueSource(ints = {0})
-    public void 存在しない商品IDを指定して更新したときに期待通り例外を返すこと(Integer id) throws Exception {
+    public void 存在しない商品IDを指定して更新したときに期待通り例外を返すこと(int id) throws Exception {
         String renewedName = "Shaft";
         when(productMapper.findById(id)).thenReturn(Optional.empty());
         assertThatThrownBy(() -> productServiceImpl.updateProductById(id, renewedName))


### PR DESCRIPTION
# テスト実装
* ServiceImplTestにて「商品IDを指定して更新したときに商品情報が更新されること」テスト追加(https://github.com/Kumagai6824/Inventory-API/pull/16/commits/1a275157d2452f379aa63e0eae78a14cc04af32a)
* ServiceImplTestにて「存在しない商品IDを指定して更新したときに期待通り例外を返すこと」テスト追加(https://github.com/Kumagai6824/Inventory-API/pull/16/commits/e0099b90c8e9da993ed8a23ae249bc566d5fb9d8)
* renewedNameに30文字を入れていたが、"Shaft"へ変更。CreateFormTestでnameが30文字のときバリデーションエラーとならないことテストを追加(https://github.com/Kumagai6824/Inventory-API/pull/16/commits/3fc84c318e48813fae8b8d86a77aab1d6e6b2076)