### PR TITLE
UpdateProduct Integration Test 続き

### DIFF
--- a/src/test/java/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/UserRestApiIntegrationTest.java
@@ -243,4 +243,23 @@ public class UserRestApiIntegrationTest {
                         """
                 , updateResult, JSONCompareMode.STRICT);
     }
+
+    @Transactional
+    @DataSet(value = "products.yml")
+    @ParameterizedTest
+    @ValueSource(ints = {0, 100})
+    void 商品更新時存在しないiIDを指定した際に404を返すこと(int productId) throws Exception {
+        Product request = new Product("Shaft");
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestJson = objectMapper.writeValueAsString((request));
+        String response = mockMvc.perform(MockMvcRequestBuilders.patch("/products/" + productId)
+                        .content(requestJson).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        assertEquals("404", JsonPath.read(response, "$.status"));
+        assertEquals("/products/" + productId, JsonPath.read(response, "$.path"));
+        assertEquals("Not Found", JsonPath.read(response, "$.error"));
+        assertEquals("resource not found with id: " + productId, JsonPath.read(response, "$.message"));
+    }
 }

--- a/src/test/java/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/UserRestApiIntegrationTest.java
@@ -87,8 +87,7 @@ public class UserRestApiIntegrationTest {
         String response = mockMvc.perform(MockMvcRequestBuilders.get("/products/" + productId))
                 .andExpect(MockMvcResultMatchers.status().isNotFound())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
-
-        assertEquals("404", JsonPath.read(response, "$.status"));
+        
         assertEquals("/products/" + productId, JsonPath.read(response, "$.path"));
         assertEquals("Not Found", JsonPath.read(response, "$.error"));
         assertEquals("Product ID:" + productId + " does not exist", JsonPath.read(response, "$.message"));
@@ -257,7 +256,6 @@ public class UserRestApiIntegrationTest {
                 .andExpect(MockMvcResultMatchers.status().isNotFound())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
-        assertEquals("404", JsonPath.read(response, "$.status"));
         assertEquals("/products/" + productId, JsonPath.read(response, "$.path"));
         assertEquals("Not Found", JsonPath.read(response, "$.error"));
         assertEquals("resource not found with id: " + productId, JsonPath.read(response, "$.message"));

--- a/src/test/java/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/UserRestApiIntegrationTest.java
@@ -87,7 +87,7 @@ public class UserRestApiIntegrationTest {
         String response = mockMvc.perform(MockMvcRequestBuilders.get("/products/" + productId))
                 .andExpect(MockMvcResultMatchers.status().isNotFound())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
-        
+
         assertEquals("/products/" + productId, JsonPath.read(response, "$.path"));
         assertEquals("Not Found", JsonPath.read(response, "$.error"));
         assertEquals("Product ID:" + productId + " does not exist", JsonPath.read(response, "$.message"));
@@ -243,14 +243,14 @@ public class UserRestApiIntegrationTest {
                 , updateResult, JSONCompareMode.STRICT);
     }
 
+    @Test
     @Transactional
     @DataSet(value = "products.yml")
-    @ParameterizedTest
-    @ValueSource(ints = {0, 100})
-    void 商品更新時存在しないiIDを指定した際に404を返すこと(int productId) throws Exception {
+    void 商品更新時存在しないIDを指定した際に404を返すこと() throws Exception {
         Product request = new Product("Shaft");
         ObjectMapper objectMapper = new ObjectMapper();
         String requestJson = objectMapper.writeValueAsString((request));
+        int productId = 0;
         String response = mockMvc.perform(MockMvcRequestBuilders.patch("/products/" + productId)
                         .content(requestJson).contentType(MediaType.APPLICATION_JSON))
                 .andExpect(MockMvcResultMatchers.status().isNotFound())


### PR DESCRIPTION
#17 の続き

# 例外テストの実装
064178821609c10733d871b2df5f33479886a028
商品更新時存在しないiIDを指定した際に404を返すこと テストを追加しました。