### PR TITLE
UpdateProduct FormTest

### DIFF
--- a/src/test/java/com/raisetech/inventoryapi/UpdateFormTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/UpdateFormTest.java
@@ -1,0 +1,71 @@
+package com.raisetech.inventoryapi;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+class UpdateFormTest {
+    private static Validator validator;
+
+    @BeforeAll
+    public static void setUpValidator() {
+        Locale.setDefault(Locale.JAPAN);
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    public void nameがnullのときにバリデーションエラーとなること() {
+        UpdateForm updateForm = new UpdateForm(null);
+        Set<ConstraintViolation<UpdateForm>> violations = validator.validate(updateForm);
+        assertThat(violations).hasSize(1);
+        assertThat(violations)
+                .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                .containsExactlyInAnyOrder(tuple("name", "空白は許可されていません"));
+    }
+
+    @Test
+    public void nameが空文字のときにバリデーションエラーとなること() {
+        UpdateForm updateForm = new UpdateForm("");
+        Set<ConstraintViolation<UpdateForm>> violations = validator.validate(updateForm);
+        assertThat(violations).hasSize(1);
+        assertThat(violations)
+                .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                .containsExactlyInAnyOrder(tuple("name", "空白は許可されていません"));
+    }
+
+    @Test
+    public void nameが31文字以上のときにバリデーションエラーとなること() {
+        String name = "Shaft";
+        UpdateForm updateForm = new UpdateForm(name.repeat(6) + "1");
+        Set<ConstraintViolation<UpdateForm>> violations = validator.validate(updateForm);
+        assertThat(violations).hasSize(1);
+        assertThat(violations)
+                .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                .containsExactlyInAnyOrder(tuple("name", "0 から 30 の間のサイズにしてください"));
+    }
+
+    @Test
+    public void nameが30文字のときバリデーションエラーとならないこと() {
+        String name = "Shaft";
+        UpdateForm updateForm = new UpdateForm(name.repeat(6));
+        Set<ConstraintViolation<UpdateForm>> violations = validator.validate(updateForm);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void nameに値があるときバリデーションエラーとならないこと() {
+        UpdateForm updateForm = new UpdateForm("Shaft");
+        Set<ConstraintViolation<UpdateForm>> violations = validator.validate(updateForm);
+        assertThat(violations).isEmpty();
+    }
+}

--- a/src/test/java/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/UserRestApiIntegrationTest.java
@@ -243,4 +243,23 @@ public class UserRestApiIntegrationTest {
                         """
                 , updateResult, JSONCompareMode.STRICT);
     }
+
+    @Transactional
+    @DataSet(value = "products.yml")
+    @ParameterizedTest
+    @ValueSource(ints = {0, 100})
+    void 商品更新時存在しないiIDを指定した際に404を返すこと(int productId) throws Exception {
+        Product request = new Product("Shaft");
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestJson = objectMapper.writeValueAsString((request));
+        String response = mockMvc.perform(MockMvcRequestBuilders.patch("/products/" + productId)
+                        .content(requestJson).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        assertEquals("404", JsonPath.read(response, "$.status"));
+        assertEquals("/products/" + productId, JsonPath.read(response, "$.path"));
+        assertEquals("Not Found", JsonPath.read(response, "$.error"));
+        assertEquals("resource not found with id: " + productId, JsonPath.read(response, "$.message"));
+    }
 }

--- a/src/test/java/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/UserRestApiIntegrationTest.java
@@ -87,8 +87,7 @@ public class UserRestApiIntegrationTest {
         String response = mockMvc.perform(MockMvcRequestBuilders.get("/products/" + productId))
                 .andExpect(MockMvcResultMatchers.status().isNotFound())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
-
-        assertEquals("404", JsonPath.read(response, "$.status"));
+        
         assertEquals("/products/" + productId, JsonPath.read(response, "$.path"));
         assertEquals("Not Found", JsonPath.read(response, "$.error"));
         assertEquals("Product ID:" + productId + " does not exist", JsonPath.read(response, "$.message"));
@@ -257,7 +256,6 @@ public class UserRestApiIntegrationTest {
                 .andExpect(MockMvcResultMatchers.status().isNotFound())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
-        assertEquals("404", JsonPath.read(response, "$.status"));
         assertEquals("/products/" + productId, JsonPath.read(response, "$.path"));
         assertEquals("Not Found", JsonPath.read(response, "$.error"));
         assertEquals("resource not found with id: " + productId, JsonPath.read(response, "$.message"));


### PR DESCRIPTION
# UpdateFormTestの実装
8de1f64a4477f5dcbb9ed3d5b6a1330d711f15c5
* 各バリデーションエラーのテスト実装を行いました。
* メソッドはほぼCreateFormTestと同じ（テストの独立性と将来的な各フォームの変更の可能性を考慮し同じでも実装しました。）