### PR TITLE
deleteproduct unittestの実装

### DIFF
--- a/src/test/java/com/raisetech/inventoryapi/ProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/ProductMapperTest.java
@@ -113,4 +113,22 @@ class ProductMapperTest {
                 );
     }
 
+    @Test
+    @Sql(
+            scripts = {"classpath:/delete-products.sql", "classpath:/insert-products.sql"},
+            executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
+    )
+    @Transactional
+    void 削除処理時に存在しないIDを指定した場合空で返すこと() {
+        productMapper.deleteProductById(3);
+        List<Product> products = productMapper.findAll();
+        assertThat(productMapper.findById(3)).isEmpty();
+        assertThat(products)
+                .hasSize(2)
+                .contains(
+                        new Product(1, "Bolt 1"),
+                        new Product(2, "Washer")
+                );
+    }
+
 }

--- a/src/test/java/com/raisetech/inventoryapi/ProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/ProductMapperTest.java
@@ -119,7 +119,7 @@ class ProductMapperTest {
             executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
     )
     @Transactional
-    void 削除処理時に存在しないIDを指定した場合空で返すこと() {
+    void 削除処理時に存在しないIDを指定した場合何も削除されないこと() {
         productMapper.deleteProductById(3);
         List<Product> products = productMapper.findAll();
         assertThat(productMapper.findById(3)).isEmpty();

--- a/src/test/java/com/raisetech/inventoryapi/ProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/ProductMapperTest.java
@@ -97,4 +97,20 @@ class ProductMapperTest {
         assertThat(productMapper.findById(1)).contains(new Product(1, "Shaft"));
     }
 
+    @Test
+    @Sql(
+            scripts = {"classpath:/delete-products.sql", "classpath:/insert-products.sql"},
+            executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
+    )
+    @Transactional
+    void 削除処理が完了して商品情報が削除されること() {
+        productMapper.deleteProductById(1);
+        List<Product> products = productMapper.findAll();
+        assertThat(products)
+                .hasSize(1)
+                .contains(
+                        new Product(2, "Washer")
+                );
+    }
+
 }

--- a/src/test/java/com/raisetech/inventoryapi/ProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/ProductServiceImplTest.java
@@ -87,4 +87,13 @@ class ProductServiceImplTest {
         productServiceImpl.deleteProductById(id);
         verify(productMapper, times(1)).deleteProductById(id);
     }
+
+    @Test
+    public void 存在しない商品IDを指定して削除したときに期待通り例外を返すこと() {
+        int id = 0;
+        doReturn(Optional.empty()).when(productMapper).findById(id);
+        assertThatThrownBy(() -> productServiceImpl.deleteProductById(id))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("resource not found with id: " + id);
+    }
 }

--- a/src/test/java/com/raisetech/inventoryapi/ProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/ProductServiceImplTest.java
@@ -89,7 +89,7 @@ class ProductServiceImplTest {
     }
 
     @Test
-    public void 存在しない商品IDを指定して削除したときに期待通り例外を返すこと() {
+    public void 存在しない商品IDを指定して場合に例外を返すこと() {
         int id = 0;
         doReturn(Optional.empty()).when(productMapper).findById(id);
         assertThatThrownBy(() -> productServiceImpl.deleteProductById(id))

--- a/src/test/java/com/raisetech/inventoryapi/ProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/ProductServiceImplTest.java
@@ -79,4 +79,12 @@ class ProductServiceImplTest {
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessage("resource not found with id: " + id);
     }
+
+    @Test
+    public void 商品IDを指定して削除したときに正しく削除されること() throws Exception {
+        int id = 1;
+        when(productMapper.findById(id)).thenReturn(Optional.of(new Product()));
+        productServiceImpl.deleteProductById(id);
+        verify(productMapper, times(1)).deleteProductById(id);
+    }
 }


### PR DESCRIPTION
# 削除処理の単体テストの実装
* ProductMapperTestにて削除処理が完了して商品情報が削除されることテストの実装(https://github.com/Kumagai6824/Inventory-API/commit/f748ef8d8b79d27fbc4be0f519dfeaf54b393296)
* ProductMapperTestにて削除処理時に存在しないIDを指定した場合空で返すことテストの実装(https://github.com/Kumagai6824/Inventory-API/pull/23/commits/39efd13e62467a0b805cc5baf3855da485b68ab5)
* ProductServiceImplTestにて商品IDを指定して削除したときに正しく削除されることテストの実装(https://github.com/Kumagai6824/Inventory-API/pull/23/commits/dd6993393e5ed9cea8ff0cf6e69c5f51538da53d)
* ProductServiceImplTestにて存在しない商品IDを指定して削除したときに期待通り例外を返すことテストの実装(https://github.com/Kumagai6824/Inventory-API/pull/23/commits/d9952bc7056f25186c9b40bd7dfbe57698b7a297)