### PR TITLE
deleteproduct IntegrationTestの実装

### DIFF
--- a/src/test/java/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/UserRestApiIntegrationTest.java
@@ -278,4 +278,18 @@ public class UserRestApiIntegrationTest {
                         """
                 , deleteResult, JSONCompareMode.STRICT);
     }
+
+    @Test
+    @Transactional
+    @DataSet(value = "products.yml")
+    void 商品削除時存在しないIDを指定した際に404を返すこと() throws Exception {
+        int id = 0;
+        String response = mockMvc.perform(MockMvcRequestBuilders.delete("/products/" + id))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        assertEquals("/products/" + id, JsonPath.read(response, "$.path"));
+        assertEquals("Not Found", JsonPath.read(response, "$.error"));
+        assertEquals("resource not found with id: " + id, JsonPath.read(response, "$.message"));
+    }
 }

--- a/src/test/java/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/UserRestApiIntegrationTest.java
@@ -260,4 +260,22 @@ public class UserRestApiIntegrationTest {
         assertEquals("Not Found", JsonPath.read(response, "$.error"));
         assertEquals("resource not found with id: " + productId, JsonPath.read(response, "$.message"));
     }
+
+    @Test
+    @DataSet(value = "products.yml")
+    @ExpectedDataSet(value = {"/dataset/expectedDeletedProducts.yml"}, ignoreCols = {"id"})
+    @Transactional
+    void 商品の削除処理後DBの当該レコードが削除され200を返すこと() throws Exception {
+        int id = 1;
+        String deleteResult = mockMvc.perform(MockMvcRequestBuilders.delete("/products/" + id))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString((StandardCharsets.UTF_8));
+
+        JSONAssert.assertEquals("""
+                        {
+                           "message":"Successful operation"
+                        }
+                        """
+                , deleteResult, JSONCompareMode.STRICT);
+    }
 }

--- a/src/test/resources/dataset/expectedDeletedProducts.yml
+++ b/src/test/resources/dataset/expectedDeletedProducts.yml
@@ -1,0 +1,3 @@
+products:
+  - id: 2
+    name: "Washer"


### PR DESCRIPTION
# 削除処理の結合テストの実装
* 商品の削除処理後DBの当該レコードが削除され200を返すことテストの実装(https://github.com/Kumagai6824/Inventory-API/commit/80f4fdda4695f799abcacdc53914f140cbd59fcf)
* 商品削除時存在しないIDを指定した際に404を返すことテストの実装(https://github.com/Kumagai6824/Inventory-API/pull/24/commits/f488da3c2b518ed1d3fc231729e84f465c40ee26)