### PR TITLE
InventoryProductMapper の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@ swagger[Inventory-API](https://kumagai6824.github.io/Inventory-API/swagger/)
 ## E-R図
 
 ![ERD](images/ERD.png)
+
+## 環境変数
+
+|変数名|役割|デフォルト値|
+|----|----|----|
+|SPRING_DATASOURCE_URL|MySQLのURL|jdbc:mysql://localhost:3308/inventory_database|
+|SPRING_DATASOURCE_USERNAME|MySQLのユーザ名|user|
+|SPRING_DATASOURCE_PASSWORD|MySQLのパスワード|password|
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: password
-      MYSQL_DATABASE: name_list
+      MYSQL_DATABASE: inventory_database
       MYSQL_USER: user
       MYSQL_PASSWORD: password
     ports:

--- a/src/main/java/com/raisetech/inventoryapi/controller/InventoryProductController.java
+++ b/src/main/java/com/raisetech/inventoryapi/controller/InventoryProductController.java
@@ -1,0 +1,28 @@
+package com.raisetech.inventoryapi.controller;
+
+import com.raisetech.inventoryapi.service.InventoryProductService;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@Validated
+public class InventoryProductController {
+    private final InventoryProductService inventoryProductService;
+
+
+    public InventoryProductController(InventoryProductService inventoryProductService) {
+        this.inventoryProductService = inventoryProductService;
+    }
+
+    @GetMapping("/inventory-products/{product_id}")
+    public Map<String, Integer> getQuantityByProductId(
+            @PathVariable(value = "product_id")
+            int product_id) {
+        Integer quantity = inventoryProductService.getQuantityByProductId(product_id);
+        return Map.of("quantity", quantity);
+    }
+}

--- a/src/main/java/com/raisetech/inventoryapi/entity/InventoryProduct.java
+++ b/src/main/java/com/raisetech/inventoryapi/entity/InventoryProduct.java
@@ -1,6 +1,5 @@
 package com.raisetech.inventoryapi.entity;
 
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
@@ -9,7 +8,6 @@ import java.util.Objects;
 
 @RequiredArgsConstructor
 @Setter
-@Getter
 public class InventoryProduct {
     private int id;
     private int productId;
@@ -21,6 +19,22 @@ public class InventoryProduct {
         this.productId = productId;
         this.quantity = quantity;
         this.history = history;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public int getProductId() {
+        return productId;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public OffsetDateTime getHistory() {
+        return history;
     }
 
     @Override

--- a/src/main/java/com/raisetech/inventoryapi/exception/InventoryProductExceptionHandler.java
+++ b/src/main/java/com/raisetech/inventoryapi/exception/InventoryProductExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.raisetech.inventoryapi.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+@RestControllerAdvice
+public class InventoryProductExceptionHandler {
+
+    @ExceptionHandler(value = InventoryStillExistsException.class)
+    public ResponseEntity<Map<String, String>> handleInventoryStillExists(
+            InventoryStillExistsException e, HttpServletRequest request
+    ) {
+
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.CONFLICT.value()),
+                "error", HttpStatus.CONFLICT.getReasonPhrase(),
+                "message", e.getMessage(),
+                "path", request.getRequestURI());
+        return new ResponseEntity(body, HttpStatus.CONFLICT);
+    }
+}

--- a/src/main/java/com/raisetech/inventoryapi/exception/InventoryStillExistsException.java
+++ b/src/main/java/com/raisetech/inventoryapi/exception/InventoryStillExistsException.java
@@ -1,0 +1,19 @@
+package com.raisetech.inventoryapi.exception;
+
+public class InventoryStillExistsException extends RuntimeException {
+    public InventoryStillExistsException() {
+        super();
+    }
+
+    public InventoryStillExistsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InventoryStillExistsException(String message) {
+        super(message);
+    }
+
+    public InventoryStillExistsException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/raisetech/inventoryapi/mapper/InventoryProductMapper.java
+++ b/src/main/java/com/raisetech/inventoryapi/mapper/InventoryProductMapper.java
@@ -10,4 +10,7 @@ import java.util.Optional;
 public interface InventoryProductMapper {
     @Select("SELECT * FROM inventoryProducts where product_id = #{product_id}")
     Optional<InventoryProduct> findInventoryByProductId(int productId);
+
+    @Select("SELECT COALESCE(SUM(quantity), 0) FROM inventoryProducts where product_id = #{product_id}")
+    Integer getQuantityByProductId(int productId);
 }

--- a/src/main/java/com/raisetech/inventoryapi/mapper/InventoryProductMapper.java
+++ b/src/main/java/com/raisetech/inventoryapi/mapper/InventoryProductMapper.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 @Mapper
 public interface InventoryProductMapper {
     @Select("SELECT * FROM inventoryProducts where product_id = #{product_id}")
-    Optional<InventoryProduct> findInventoryByProductId(int product_id);
+    Optional<InventoryProduct> findInventoryByProductId(int productId);
 }

--- a/src/main/java/com/raisetech/inventoryapi/mapper/InventoryProductMapper.java
+++ b/src/main/java/com/raisetech/inventoryapi/mapper/InventoryProductMapper.java
@@ -1,0 +1,13 @@
+package com.raisetech.inventoryapi.mapper;
+
+import com.raisetech.inventoryapi.entity.InventoryProduct;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+
+import java.util.Optional;
+
+@Mapper
+public interface InventoryProductMapper {
+    @Select("SELECT * FROM inventoryProducts where product_id = #{product_id}")
+    Optional<InventoryProduct> findInventoryByProductId(int product_id);
+}

--- a/src/main/java/com/raisetech/inventoryapi/service/InventoryProductService.java
+++ b/src/main/java/com/raisetech/inventoryapi/service/InventoryProductService.java
@@ -1,0 +1,5 @@
+package com.raisetech.inventoryapi.service;
+
+public interface InventoryProductService {
+    Integer getQuantityByProductId(int productId);
+}

--- a/src/main/java/com/raisetech/inventoryapi/service/InventoryProductServiceImpl.java
+++ b/src/main/java/com/raisetech/inventoryapi/service/InventoryProductServiceImpl.java
@@ -1,0 +1,20 @@
+package com.raisetech.inventoryapi.service;
+
+import com.raisetech.inventoryapi.mapper.InventoryProductMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+public class InventoryProductServiceImpl implements InventoryProductService {
+    private final InventoryProductMapper inventoryProductMapper;
+
+    public InventoryProductServiceImpl(InventoryProductMapper inventoryProductMapper) {
+        this.inventoryProductMapper = inventoryProductMapper;
+    }
+    
+    @Override
+    public Integer getQuantityByProductId(int productId) {
+        Integer quantity = this.inventoryProductMapper.getQuantityByProductId(productId);
+        return quantity;
+    }
+
+}

--- a/src/main/java/com/raisetech/inventoryapi/service/ProductServiceImpl.java
+++ b/src/main/java/com/raisetech/inventoryapi/service/ProductServiceImpl.java
@@ -1,14 +1,13 @@
 package com.raisetech.inventoryapi.service;
 
-import com.raisetech.inventoryapi.entity.InventoryProduct;
 import com.raisetech.inventoryapi.entity.Product;
+import com.raisetech.inventoryapi.exception.InventoryStillExistsException;
 import com.raisetech.inventoryapi.exception.ResourceNotFoundException;
 import com.raisetech.inventoryapi.mapper.InventoryProductMapper;
 import com.raisetech.inventoryapi.mapper.ProductMapper;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 public class ProductServiceImpl implements ProductService {
@@ -44,17 +43,12 @@ public class ProductServiceImpl implements ProductService {
     @Override
     public void deleteProductById(int id) {
         productMapper.findById(id).orElseThrow(() -> new ResourceNotFoundException("resource not found with id: " + id));
-        Optional<InventoryProduct> inventoryProductOptional = inventoryProductMapper.findInventoryByProductId(id);
-        if (inventoryProductOptional.isPresent()) {
-            InventoryProduct inventoryProduct = inventoryProductOptional.get();
-            int quantity = inventoryProduct.getQuantity();
-            if (quantity == 0) {
-                productMapper.deleteProductById(id);
-            } else {
-                throw new IllegalStateException("Cannot delete Product because the quantity is 0");
-            }
-        } else {
+        Integer quantity = inventoryProductMapper.getQuantityByProductId(id);
+
+        if (quantity == 0) {
             productMapper.deleteProductById(id);
+        } else {
+            throw new InventoryStillExistsException("Cannot delete Product because the quantity is not 0");
         }
     }
 }

--- a/src/test/java/com/raisetech/inventoryapi/ProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/ProductServiceImplTest.java
@@ -1,7 +1,9 @@
 package com.raisetech.inventoryapi;
 
+import com.raisetech.inventoryapi.entity.InventoryProduct;
 import com.raisetech.inventoryapi.entity.Product;
 import com.raisetech.inventoryapi.exception.ResourceNotFoundException;
+import com.raisetech.inventoryapi.mapper.InventoryProductMapper;
 import com.raisetech.inventoryapi.mapper.ProductMapper;
 import com.raisetech.inventoryapi.service.ProductServiceImpl;
 import org.junit.jupiter.api.Test;
@@ -29,6 +31,8 @@ class ProductServiceImplTest {
     ProductMapper productMapper;
     @MockBean
     private BindingResult bindingResult;
+    @Mock
+    InventoryProductMapper inventoryProductMapper;
 
     @Test
     public void 製品情報を全件取得できること() {
@@ -85,10 +89,19 @@ class ProductServiceImplTest {
     }
 
     @Test
-    public void 商品IDを指定して削除したときに正しく削除されること() throws Exception {
+    public void 商品を削除した際在庫が0個なら削除されること() throws Exception {
         int id = 1;
-        when(productMapper.findById(id)).thenReturn(Optional.of(new Product()));
+        Product product = new Product();
+        product.setId(id);
+
+        InventoryProduct inventoryProduct = new InventoryProduct();
+        inventoryProduct.setQuantity(0);
+
+        when(productMapper.findById(id)).thenReturn(Optional.of(product));
+        when(inventoryProductMapper.findInventoryByProductId(id)).thenReturn(Optional.of(inventoryProduct));
+
         productServiceImpl.deleteProductById(id);
+
         verify(productMapper, times(1)).deleteProductById(id);
     }
 

--- a/src/test/java/com/raisetech/inventoryapi/ProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/ProductServiceImplTest.java
@@ -94,11 +94,13 @@ class ProductServiceImplTest {
         Product product = new Product();
         product.setId(id);
 
+        int quantity = 0;
+
         InventoryProduct inventoryProduct = new InventoryProduct();
-        inventoryProduct.setQuantity(0);
+        inventoryProduct.setQuantity(quantity);
 
         when(productMapper.findById(id)).thenReturn(Optional.of(product));
-        when(inventoryProductMapper.findInventoryByProductId(id)).thenReturn(Optional.of(inventoryProduct));
+        when(inventoryProductMapper.getQuantityByProductId(id)).thenReturn(quantity);
 
         productServiceImpl.deleteProductById(id);
 
@@ -106,7 +108,7 @@ class ProductServiceImplTest {
     }
 
     @Test
-    public void 存在しない商品IDを指定して場合に例外を返すこと() {
+    public void 存在しない商品IDを指定して削除した場合に例外を返すこと() {
         int id = 0;
         doReturn(Optional.empty()).when(productMapper).findById(id);
         assertThatThrownBy(() -> productServiceImpl.deleteProductById(id))

--- a/src/test/resources/dbunit.yml
+++ b/src/test/resources/dbunit.yml
@@ -1,9 +1,9 @@
 cacheConnection: false
 cacheTableNames: false
 properties:
-  schema: name_list
+  schema: inventory_database
 caseInsensitiveStrategy: LOWERCASE
 connectionConfig:
-  url: "jdbc:mysql://localhost:3308/name_list"
+  url: "jdbc:mysql://localhost:3308/inventory_database"
   user: "user"
   password: "password"


### PR DESCRIPTION
# 概要
* mapperの実装を行いました。(https://github.com/Kumagai6824/Inventory-API/pull/27/commits/4a0b7491fa60c57e895c0ce8f2e959ae656c0d1c)
* ProductServiceImplにて削除処理での`quantity=0`時はproductの削除へ、そうでないときはproductは削除しない処理を追加　※例外は別途専用例外クラスを実装したいと考えています。(https://github.com/Kumagai6824/Inventory-API/pull/27/commits/49374a3e0286ba6c0f707a9ee3351885c3fa3e94)
* InventoryProductにてgetter追加(https://github.com/Kumagai6824/Inventory-API/pull/27/commits/d564a4eec5dd07eb7bfd3b3d4a5cea4cb1a79525)
* ServiceImplテストにて商品を削除した際在庫が0個なら削除されることテスト実装(https://github.com/Kumagai6824/Inventory-API/pull/27/commits/b31bfa1f84c5e6e5bc1546b32d2aad5dd011c38e)
* 0個じゃないなら例外スローして削除されないことテスト→後日実装します。


# 実行結果
## inventoryProductsテーブルの状況
![image](https://github.com/Kumagai6824/Inventory-API/assets/117643710/0233b06f-d389-4639-a3ef-63a0d2363bed)

## productsテーブルの状況
![image](https://github.com/Kumagai6824/Inventory-API/assets/117643710/b2d28cf2-74c8-48ca-ae2c-7e67d8d0827a)

## productsテーブルのid:3, name:Gearを削除
![image](https://github.com/Kumagai6824/Inventory-API/assets/117643710/8b3217cd-006c-4ef8-b57c-3afbb223edb7)

## productsテーブルのid:1, name:Bolt 1を削除
![image](https://github.com/Kumagai6824/Inventory-API/assets/117643710/9731ca95-9319-4027-98fd-e62c59debc5a)

id:1 については500が返っているが、少なくともquantityが0のものと0じゃないものとで挙動が違うことはわかる。
