### PR TITLE
InventoryStillExistsExceptionの実装

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/exception/InventoryProductExceptionHandler.java
+++ b/src/main/java/com/raisetech/inventoryapi/exception/InventoryProductExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.raisetech.inventoryapi.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+@RestControllerAdvice
+public class InventoryProductExceptionHandler {
+
+    @ExceptionHandler(value = InventoryStillExistsException.class)
+    public ResponseEntity<Map<String, String>> handleInventoryStillExists(
+            InventoryStillExistsException e, HttpServletRequest request
+    ) {
+
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.CONFLICT.value()),
+                "error", HttpStatus.CONFLICT.getReasonPhrase(),
+                "message", e.getMessage(),
+                "path", request.getRequestURI());
+        return new ResponseEntity(body, HttpStatus.CONFLICT);
+    }
+}

--- a/src/main/java/com/raisetech/inventoryapi/exception/InventoryStillExistsException.java
+++ b/src/main/java/com/raisetech/inventoryapi/exception/InventoryStillExistsException.java
@@ -1,0 +1,19 @@
+package com.raisetech.inventoryapi.exception;
+
+public class InventoryStillExistsException extends RuntimeException {
+    public InventoryStillExistsException() {
+        super();
+    }
+
+    public InventoryStillExistsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InventoryStillExistsException(String message) {
+        super(message);
+    }
+
+    public InventoryStillExistsException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
# 概要
[こちら](https://github.com/Kumagai6824/Inventory-API/pull/27#issue-2197415198)の例外クラスの実装を行いました。

* InventoryStillExistsExceptionクラスの実装(https://github.com/Kumagai6824/Inventory-API/commit/3addd443b3701c921fa0507e11627d60ee93bae8)
* InventoryProductExceptionHandlerクラスの実装(https://github.com/Kumagai6824/Inventory-API/pull/28/commits/0bdd8a16cbfcf00a2c8e12e0f488a4d4d079328d)
  * HttpStatus409(Conflict)は今回の例外スロー内容が「ユーザーの削除リクエストに対し、在庫があるから削除できない」とするサーバー側の状態とconflictする場合、という認識で設定しました（選択にはchatgpt利用）。
![image](https://github.com/Kumagai6824/Inventory-API/assets/117643710/038fb48f-1572-4654-97e8-4579d5e0233c)



# 実行結果
productsテーブルの状況
![image](https://github.com/Kumagai6824/Inventory-API/assets/117643710/fb3af3a2-2adb-4307-8567-defb500b9a6e)

inventoryProductsテーブルの状況
![image](https://github.com/Kumagai6824/Inventory-API/assets/117643710/c06594cb-50d6-4aba-bef2-26fe30eabd78)

在庫がゼロじゃない商品（id=1）の削除時のレスポンス
![image](https://github.com/Kumagai6824/Inventory-API/assets/117643710/18fe58a6-301c-4d14-a622-763fe98732bb)

在庫がゼロの商品（id=5）の削除時のレスポンス
![image](https://github.com/Kumagai6824/Inventory-API/assets/117643710/87320599-e61f-40f3-bf0a-777637942fa1)
