### PR TITLE
論理削除のテスト実装

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x ./gradlew
       - name: Conduct Tests
-        run: gradle test
+        run: TZ=Asia/Tokyo gradle test
         if: always()
 
       - name: Publish Test Report

--- a/src/main/java/com/raisetech/inventoryapi/entity/Product.java
+++ b/src/main/java/com/raisetech/inventoryapi/entity/Product.java
@@ -3,7 +3,7 @@ package com.raisetech.inventoryapi.entity;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
-import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.Objects;
 
 @RequiredArgsConstructor
@@ -11,13 +11,13 @@ import java.util.Objects;
 public class Product {
     private int id;
     private String name;
-    private OffsetDateTime deletedAt;
+    private ZonedDateTime deletedAt;
 
     public Product(String name) {
         this.name = name;
     }
 
-    public Product(int id, String name, OffsetDateTime deletedAt) {
+    public Product(int id, String name, ZonedDateTime deletedAt) {
         this.id = id;
         this.name = name;
         this.deletedAt = deletedAt;
@@ -31,7 +31,7 @@ public class Product {
         return name;
     }
 
-    public OffsetDateTime getDeletedAt() {
+    public ZonedDateTime getDeletedAt() {
         return deletedAt;
     }
 

--- a/src/main/java/com/raisetech/inventoryapi/entity/Product.java
+++ b/src/main/java/com/raisetech/inventoryapi/entity/Product.java
@@ -3,7 +3,7 @@ package com.raisetech.inventoryapi.entity;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
-import java.time.ZonedDateTime;
+import java.time.OffsetDateTime;
 import java.util.Objects;
 
 @RequiredArgsConstructor
@@ -11,13 +11,13 @@ import java.util.Objects;
 public class Product {
     private int id;
     private String name;
-    private ZonedDateTime deletedAt;
+    private OffsetDateTime deletedAt;
 
     public Product(String name) {
         this.name = name;
     }
 
-    public Product(int id, String name, ZonedDateTime deletedAt) {
+    public Product(int id, String name, OffsetDateTime deletedAt) {
         this.id = id;
         this.name = name;
         this.deletedAt = deletedAt;
@@ -31,7 +31,7 @@ public class Product {
         return name;
     }
 
-    public ZonedDateTime getDeletedAt() {
+    public OffsetDateTime getDeletedAt() {
         return deletedAt;
     }
 

--- a/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
@@ -8,8 +8,6 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.OffsetDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 
@@ -106,10 +104,8 @@ class ProductMapperTest {
             executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
     )
     @Transactional
-    void 論理削除でdeletedAtに処理日時が入ること() {
-        OffsetDateTime beforeDeletion = OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS);
+    void 論理削除後にdeletedAtがnullではないこと() {
         productMapper.deleteProductById(1);
-        OffsetDateTime afterDeletion = OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS);
 
         List<Product> products = productMapper.findAll();
 
@@ -119,7 +115,6 @@ class ProductMapperTest {
                 .first()
                 .satisfies(product -> {
                     assertThat(product.getDeletedAt()).isNotNull();
-                    assertThat(product.getDeletedAt()).isBetween(beforeDeletion, afterDeletion);
                 });
     }
 

--- a/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
@@ -9,7 +9,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.ZonedDateTime;
+import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
@@ -114,9 +114,9 @@ class ProductMapperTest {
     )
     @Transactional
     void 論理削除後にdeletedAtがnullではないこと() {
-        ZonedDateTime beforeDeletion = ZonedDateTime.now().truncatedTo(ChronoUnit.SECONDS);
+        OffsetDateTime beforeDeletion = OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS);
         productMapper.deleteProductById(1);
-        ZonedDateTime afterDeletion = ZonedDateTime.now().truncatedTo(ChronoUnit.SECONDS);
+        OffsetDateTime afterDeletion = OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS);
         List<Product> products = productMapper.findAll();
         assertThat(products)
                 .hasSize(2)

--- a/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
@@ -9,7 +9,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
@@ -114,9 +114,9 @@ class ProductMapperTest {
     )
     @Transactional
     void 論理削除後にdeletedAtがnullではないこと() {
-        OffsetDateTime beforeDeletion = OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS);
+        ZonedDateTime beforeDeletion = ZonedDateTime.now().truncatedTo(ChronoUnit.SECONDS);
         productMapper.deleteProductById(1);
-        OffsetDateTime afterDeletion = OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS);
+        ZonedDateTime afterDeletion = ZonedDateTime.now().truncatedTo(ChronoUnit.SECONDS);
         List<Product> products = productMapper.findAll();
         assertThat(products)
                 .hasSize(2)

--- a/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
@@ -28,7 +28,7 @@ class ProductMapperTest {
 
     @BeforeEach
     public void setDefaultTimeZone() {
-        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Tokyo"));
     }
 
     @Test

--- a/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
@@ -10,6 +10,7 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
@@ -114,9 +115,9 @@ class ProductMapperTest {
     )
     @Transactional
     void 論理削除後にdeletedAtがnullではないこと() {
-        OffsetDateTime beforeDeletion = OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS);
+        OffsetDateTime beforeDeletion = OffsetDateTime.now(ZoneOffset.ofHours(9)).truncatedTo(ChronoUnit.SECONDS);
         productMapper.deleteProductById(1);
-        OffsetDateTime afterDeletion = OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS);
+        OffsetDateTime afterDeletion = OffsetDateTime.now(ZoneOffset.ofHours(9)).truncatedTo(ChronoUnit.SECONDS);
         List<Product> products = productMapper.findAll();
         assertThat(products)
                 .hasSize(2)

--- a/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
@@ -113,7 +113,7 @@ class ProductMapperTest {
             executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
     )
     @Transactional
-    void 論理削除後にdeletedAtがnullではないこと() {
+    void 論理削除後にdeletedAtに処理日時が入ること() {
         OffsetDateTime beforeDeletion = OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS);
         productMapper.deleteProductById(1);
         OffsetDateTime afterDeletion = OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS);

--- a/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
@@ -115,9 +115,9 @@ class ProductMapperTest {
     )
     @Transactional
     void 論理削除後にdeletedAtがnullではないこと() {
-        OffsetDateTime beforeDeletion = OffsetDateTime.now(ZoneOffset.ofHours(9)).truncatedTo(ChronoUnit.SECONDS);
+        OffsetDateTime beforeDeletion = OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS);
         productMapper.deleteProductById(1);
-        OffsetDateTime afterDeletion = OffsetDateTime.now(ZoneOffset.ofHours(9)).truncatedTo(ChronoUnit.SECONDS);
+        OffsetDateTime afterDeletion = OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS);
         List<Product> products = productMapper.findAll();
         assertThat(products)
                 .hasSize(2)

--- a/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
@@ -1,7 +1,7 @@
 package com.raisetech.inventoryapi.mapper;
 
 import com.raisetech.inventoryapi.entity.Product;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,7 +10,6 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
@@ -27,9 +26,9 @@ class ProductMapperTest {
     @Autowired
     ProductMapper productMapper;
 
-    @BeforeAll
-    public static void setDefaultTimeZone() {
-        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Tokyo"));
+    @BeforeEach
+    public void setDefaultTimeZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
     }
 
     @Test
@@ -115,9 +114,9 @@ class ProductMapperTest {
     )
     @Transactional
     void 論理削除後にdeletedAtがnullではないこと() {
-        OffsetDateTime beforeDeletion = OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS);
+        OffsetDateTime beforeDeletion = OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS);
         productMapper.deleteProductById(1);
-        OffsetDateTime afterDeletion = OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS);
+        OffsetDateTime afterDeletion = OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS);
         List<Product> products = productMapper.findAll();
         assertThat(products)
                 .hasSize(2)

--- a/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
@@ -130,4 +130,21 @@ class ProductMapperTest {
 
     }
 
+    @Test
+    @Sql(
+            scripts = {"classpath:/delete-products.sql", "classpath:/insert-products.sql"},
+            executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
+    )
+    @Transactional
+    void 存在しない商品IDで削除してもレコードに影響がないこと() {
+        productMapper.deleteProductById(0);
+        List<Product> products = productMapper.findAll();
+        assertThat(products)
+                .hasSize(2)
+                .contains(
+                        new Product(1, "Bolt 1", null),
+                        new Product(2, "Washer", null)
+                );
+    }
+
 }

--- a/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
@@ -129,17 +129,5 @@ class ProductMapperTest {
 
 
     }
-/*        productMapper.deleteProductById(1);
-
-        List<Product> products = productMapper.findAll();
-
-        assertThat(products)
-                .hasSize(2)
-                .filteredOn(product -> product.getId() == 1)
-                .first()
-                .satisfies(product -> {
-                    assertThat(product.getDeletedAt()).isNotNull();
-                });
-    }*/
 
 }

--- a/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
@@ -28,7 +28,7 @@ class ProductMapperTest {
 
     @BeforeAll
     public static void setDefaultTimeZone() {
-        TimeZone.setDefault(TimeZone.getTimeZone("UTC+09:00"));
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Tokyo"));
     }
 
     @Test

--- a/src/test/java/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/UserRestApiIntegrationTest.java
@@ -285,7 +285,6 @@ public class UserRestApiIntegrationTest {
                         """
                 , deleteResult, JSONCompareMode.STRICT);
 
-        //Define the expected dataset as a JSON string
         String expectedDeletedProductsJson = """
                 {
                   "products": [
@@ -303,7 +302,6 @@ public class UserRestApiIntegrationTest {
                 }                
                 """;
 
-        //Parse the JSON string and extract the 'deletedAt' field for the specific product
         JSONArray expectedDeletedProductsArray = new JSONObject(expectedDeletedProductsJson)
                 .getJSONArray("products");
 
@@ -314,8 +312,7 @@ public class UserRestApiIntegrationTest {
                 OffsetDateTime expectedDeletedAt = expectedProduct.isNull("deletedAt") ? null :
                         OffsetDateTime.parse(expectedProduct.getString("deletedAt"),
                                 DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-
-                //Perform assertions on the 'deletedAt' field
+                
                 assertThat(expectedDeletedAt).isNotNull();
             }
         }

--- a/src/test/resources/dataset/expectedDeletedProducts.yml
+++ b/src/test/resources/dataset/expectedDeletedProducts.yml
@@ -1,3 +1,0 @@
-products:
-  - id: 2
-    name: "Washer"


### PR DESCRIPTION
# Mapper正常テスト実装



* MapperTestにて論理削除後にdeletedAtに日付が入ることテストの実装(https://github.com/Kumagai6824/Inventory-API/pull/33/commits/5c158d507c342ac4e2a948a732650f7a6d843415)
* メソッド名修正(https://github.com/Kumagai6824/Inventory-API/pull/33/commits/bf7613d81469739038d00f2a53d74ff880896562)

--------------------------
## テストfail

* MapperTestにて論理削除でdeletedAtに処理日時が入ることテストの実装(https://github.com/Kumagai6824/Inventory-API/commit/3c98f2c0fadd86e30590ab63e744a99cff4ee9b5)

"deletedAt"は削除実行時の日付が入りますが、日付をassertでどのように確認できるのか（mapperでは、sql文で"deleted_atカラムにNOW()で日付を入れている）分からず、chatGPTで実装方法を確認したところ、OffsetDateTime.now()を削除実行前後で取得し、assertThatのisBetweenで実行時のdatetimeが範囲内かどうかを確認するという方法が出てきました。まずはこの方法で実装しました。

ローカルpcではテスト成功したものの、CIでテストfailした。
OffsetDateTime.now() の取得が環境によって異なってしまうことが原因と推測。
対応としては、まずは削除フラグがnullかnullじゃないか、で判断できれば足りる？と考えました。
論理削除品はdeletedAtがnullじゃないこと、のみに絞りテスト修正しました。

## TimeZoneの確認

* MySql　→問題なさそう？
![image](https://github.com/Kumagai6824/Inventory-API/assets/117643710/9d7f0db2-94fc-446b-a721-9447abeba71f)

* MapperTestにて@BeforeAllでUTC+09:00の設定(https://github.com/Kumagai6824/Inventory-API/pull/33/commits/99111d64dba903172126516c9034a2eed32caee4) fail
```
Expecting actual:
  2024-05-02T22:51:55Z (java.time.OffsetDateTime)
to be between:
  [2024-05-02T13:51:55Z (java.time.OffsetDateTime), 2024-05-02T13:51:55Z (java.time.OffsetDateTime)]
```

* TimeZoneIdをUTC+09:00からAsia/Tokyoへ変更(https://github.com/Kumagai6824/Inventory-API/pull/33/commits/1e55dd474647797817fc673f1cc3fdb2b75e5d79) fail

```
Expecting actual:
  2024-05-02T23:00:21Z (java.time.OffsetDateTime)
to be between:
  [2024-05-02T23:00:21+09:00 (java.time.OffsetDateTime), 2024-05-02T23:00:21+09:00 (java.time.OffsetDateTime)]
```

時間はUTC+09:00になった？けど、なぜかassertionエラー

* OffsetDateTime.now(ZoneOffset.ofHours(9))を設定(https://github.com/Kumagai6824/Inventory-API/pull/33/commits/4104f93aae77ba8cac252ac7dc77b4fadfd6b17d) fail

```
Expecting actual:
  2024-05-03T08:13:51Z (java.time.OffsetDateTime)
to be between:
  [2024-05-03T08:13:51+09:00 (java.time.OffsetDateTime), 2024-05-03T08:13:51+09:00 (java.time.OffsetDateTime)]
```

結果は変わりなし、末尾のZと+09:00の違いが要因？

* OffsetDateTime.now(ZoneOFfset.UTC)を設定(https://github.com/Kumagai6824/Inventory-API/pull/33/commits/a321d931fa5099c29bc8452f3f78807c1c7e974e) fail

```
Expecting actual:
  2024-05-03T08:26:28Z (java.time.OffsetDateTime)
to be between:
  [2024-05-02T23:26:28Z (java.time.OffsetDateTime), 2024-05-02T23:26:28Z (java.time.OffsetDateTime)]
```

assert用の日付がUTCになって、Testの日付はUTC+09:00ということ？で、戻ってしまった。

* @BeforeEachでZoneIdをAsia/Tokyoにしてみる(https://github.com/Kumagai6824/Inventory-API/pull/33/commits/ea7e3a13161cfe2777cb4b08da8c3a02525d66ea) (https://github.com/Kumagai6824/Inventory-API/pull/33/commits/dc999ddad878cfd2928ee7b2a5d06896e6017f0e) fail

```
Expecting actual:
  2024-05-03T08:54:51Z (java.time.OffsetDateTime)
to be between:
  [2024-05-03T08:54:51+09:00 (java.time.OffsetDateTime), 2024-05-03T08:54:51+09:00 (java.time.OffsetDateTime)]
```

時間はどちらもUTC+09:00になった？でもassertionエラー

* OffsetDateTimeをZonedDateTimeへ変更（Mapperテストとエンティティ）(https://github.com/Kumagai6824/Inventory-API/pull/33/commits/166509c816c7d1ac31d5778518504587bd62b430) faild

```
Expecting actual:
  2024-05-03T11:11:07Z[Etc/UTC] (java.time.ZonedDateTime)
to be between:
  [2024-05-03T11:11:07+09:00[Asia/Tokyo] (java.time.ZonedDateTime), 2024-05-03T11:11:07+09:00[Asia/Tokyo] (java.time.ZonedDateTime)]
```

* Github actions  workflows/gradle.ymlにてAsia/Tokyoを設定(https://github.com/Kumagai6824/Inventory-API/pull/33/commits/a20f768c616ae6c37d0c9bc083d2ab335a9c8ae1)

![image](https://github.com/Kumagai6824/Inventory-API/assets/117643710/24cbad38-fab7-422c-978f-247007b40722)

