### PR TITLE
未削除レコード対応（deleted_at is null等）

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/mapper/ProductMapper.java
+++ b/src/main/java/com/raisetech/inventoryapi/mapper/ProductMapper.java
@@ -20,7 +20,7 @@ public interface ProductMapper {
     @Options(useGeneratedKeys = true, keyProperty = "id")
     void createProduct(Product product);
 
-    @Update("UPDATE products SET name = #{name} WHERE id =#{id}")
+    @Update("UPDATE products SET name = #{name} WHERE id =#{id} and deleted_at IS NULL")
     void updateProductById(int id, String name);
 
     @Update("UPDATE products SET deleted_at = now() where id =#{id}")

--- a/src/main/java/com/raisetech/inventoryapi/mapper/ProductMapper.java
+++ b/src/main/java/com/raisetech/inventoryapi/mapper/ProductMapper.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 @Mapper
 public interface ProductMapper {
-    @Select("SELECT * FROM products")
+    @Select("SELECT * FROM products where deleted_at IS NULL")
     @Result(property = "deletedAt", column = "deleted_at")
     List<Product> findAll();
 

--- a/src/main/java/com/raisetech/inventoryapi/mapper/ProductMapper.java
+++ b/src/main/java/com/raisetech/inventoryapi/mapper/ProductMapper.java
@@ -11,7 +11,7 @@ public interface ProductMapper {
     @Select("SELECT * FROM products where deleted_at IS NULL")
     @Result(property = "deletedAt", column = "deleted_at")
     List<Product> findAll();
-
+    
     @Select("SELECT * FROM products where id = #{id}")
     @Result(property = "deletedAt", column = "deleted_at")
     Optional<Product> findById(int id);

--- a/src/main/java/com/raisetech/inventoryapi/mapper/ProductMapper.java
+++ b/src/main/java/com/raisetech/inventoryapi/mapper/ProductMapper.java
@@ -11,8 +11,8 @@ public interface ProductMapper {
     @Select("SELECT * FROM products where deleted_at IS NULL")
     @Result(property = "deletedAt", column = "deleted_at")
     List<Product> findAll();
-    
-    @Select("SELECT * FROM products where id = #{id}")
+
+    @Select("SELECT * FROM products where id = #{id} and deleted_at IS NULL")
     @Result(property = "deletedAt", column = "deleted_at")
     Optional<Product> findById(int id);
 

--- a/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
@@ -82,6 +82,18 @@ class ProductMapperTest {
 
     @Test
     @Sql(
+            scripts = {"classpath:/delete-products.sql", "classpath:/insert-products.sql"},
+            executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
+    )
+    @Transactional
+    void 削除した商品IDを指定したときに空で返すこと() {
+        productMapper.deleteProductById(1);
+        Optional<Product> product = productMapper.findById(1);
+        assertThat(product).isEmpty();
+    }
+
+    @Test
+    @Sql(
             scripts = {"classpath:/delete-products.sql", "classpath:/reset-id.sql"},
             executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
     )

--- a/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
@@ -9,8 +9,6 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.OffsetDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import java.util.TimeZone;
@@ -113,21 +111,14 @@ class ProductMapperTest {
             executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
     )
     @Transactional
-    void 論理削除後にdeletedAtに処理日時が入ること() {
-        OffsetDateTime beforeDeletion = OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS);
+    void 削除後に論理削除されたレコードが取得されないこと() {
         productMapper.deleteProductById(1);
-        OffsetDateTime afterDeletion = OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS);
         List<Product> products = productMapper.findAll();
         assertThat(products)
-                .hasSize(2)
-                .filteredOn(product -> product.getId() == 1)
-                .first()
-                .satisfies(product -> {
-                    assertThat(product.getDeletedAt()).isNotNull();
-                    assertThat(product.getDeletedAt()).isBetween(beforeDeletion, afterDeletion);
-                });
-
-
+                .hasSize(1)
+                .contains(
+                        new Product(2, "Washer", null)
+                );
     }
 
     @Test

--- a/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
@@ -123,6 +123,19 @@ class ProductMapperTest {
             executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
     )
     @Transactional
+    void 削除済みレコードを更新しても処理されないこと() {
+        productMapper.deleteProductById(1);
+        productMapper.updateProductById(1, "updatedName");
+        assertThat(productMapper.findById(1)).isEmpty();
+
+    }
+
+    @Test
+    @Sql(
+            scripts = {"classpath:/delete-products.sql", "classpath:/insert-products.sql"},
+            executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
+    )
+    @Transactional
     void 削除後に論理削除されたレコードが取得されないこと() {
         productMapper.deleteProductById(1);
         List<Product> products = productMapper.findAll();

--- a/src/test/java/com/raisetech/inventoryapi/service/ProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/service/ProductServiceImplTest.java
@@ -59,6 +59,26 @@ class ProductServiceImplTest {
     }
 
     @Test
+    public void 削除した商品IDを指定したときに例外を返すこと() {
+        int id = 1;
+        int quantity = 0;
+        InventoryProduct inventoryProduct = new InventoryProduct();
+        inventoryProduct.setQuantity(quantity);
+        when(inventoryProductMapper.getQuantityByProductId(id)).thenReturn(quantity);
+
+        when(productMapper.findById(id)).thenReturn(Optional.of(new Product()));
+
+        productServiceImpl.deleteProductById(id);
+        verify(productMapper).findById(id);
+
+        when(productMapper.findById(id)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> productServiceImpl.findById(id))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Product ID:" + id + " does not exist");
+    }
+
+    @Test
     public void 商品が正しく1件登録されること() throws Exception {
         Product product = new Product("test product");
         doNothing().when(productMapper).createProduct(product);

--- a/src/test/java/com/raisetech/inventoryapi/service/ProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/service/ProductServiceImplTest.java
@@ -108,6 +108,22 @@ class ProductServiceImplTest {
     }
 
     @Test
+    public void 削除済み商品を更新したときに例外を返すこと() throws Exception {
+        int id = 1;
+        String renewedName = "Shaft";
+        when(productMapper.findById(id)).thenReturn(Optional.of(new Product()));
+
+        productServiceImpl.deleteProductById(id);
+        verify(productMapper).deleteProductById(id);
+        
+        when(productMapper.findById(id)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> productServiceImpl.updateProductById(id, renewedName))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("resource not found with id: " + id);
+    }
+
+    @Test
     public void 商品を削除した際在庫が0個なら削除されること() throws Exception {
         int id = 1;
         Product product = new Product();

--- a/src/test/java/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/UserRestApiIntegrationTest.java
@@ -285,6 +285,25 @@ public class UserRestApiIntegrationTest {
     }
 
     @Test
+    @Transactional
+    @DataSet(value = "products.yml")
+    void 削除した商品を更新した際に404を返すこと() throws Exception {
+        Product request = new Product("Shaft");
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestJson = objectMapper.writeValueAsString((request));
+        int productId = 1;
+        mockMvc.perform(MockMvcRequestBuilders.delete("/products/" + productId));
+        String response = mockMvc.perform(MockMvcRequestBuilders.patch("/products/" + productId)
+                        .content(requestJson).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        assertEquals("/products/" + productId, JsonPath.read(response, "$.path"));
+        assertEquals("Not Found", JsonPath.read(response, "$.error"));
+        assertEquals("resource not found with id: " + productId, JsonPath.read(response, "$.message"));
+    }
+
+    @Test
     @DataSet(value = "products.yml")
     @Transactional
     void 商品の削除処理後当該レコードの削除フラグに日付が入り200を返すこと() throws Exception {

--- a/src/test/java/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/UserRestApiIntegrationTest.java
@@ -102,6 +102,21 @@ public class UserRestApiIntegrationTest {
     }
 
     @Test
+    @Transactional
+    @DataSet(value = "products.yml")
+    void 削除したIDを指定した際404を返すこと() throws Exception {
+        int productId = 1;
+        mockMvc.perform(MockMvcRequestBuilders.delete("/products/" + productId));
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/products/" + productId))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        assertEquals("/products/" + productId, JsonPath.read(response, "$.path"));
+        assertEquals("Not Found", JsonPath.read(response, "$.error"));
+        assertEquals("Product ID:" + productId + " does not exist", JsonPath.read(response, "$.message"));
+    }
+
+    @Test
     @DataSet(value = "products.yml")
     @Transactional
     void 新規商品を登録でき201を返すこと() throws Exception {
@@ -312,7 +327,7 @@ public class UserRestApiIntegrationTest {
                 OffsetDateTime expectedDeletedAt = expectedProduct.isNull("deletedAt") ? null :
                         OffsetDateTime.parse(expectedProduct.getString("deletedAt"),
                                 DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-                
+
                 assertThat(expectedDeletedAt).isNotNull();
             }
         }


### PR DESCRIPTION
# findAllの変更

論理削除実装のため、mapperのfindAllメソッドを変更（deleted_at is null を追加）しました。
deleted_at=null →未削除レコードのこと

```
    @Select("SELECT * FROM products where deleted_at IS NULL")
    @Result(property = "deletedAt", column = "deleted_at")
    List<Product> findAll();
```

* findAllメソッド変更(https://github.com/Kumagai6824/Inventory-API/pull/34/commits/8f491def233051d233da5d0dace7dd1d22c49b91)
* MapperTestを「削除後に論理削除されたレコードが取得されないこと」へ変更（findAllメソッドの変更により、論理削除されたレコードは取得されない為）(https://github.com/Kumagai6824/Inventory-API/pull/34/commits/748e49b1e5e101ffb801a3321f983aec1b8bf264)