### PR TITLE
在庫履歴取得機能（Service）の実装

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/service/ProductService.java
+++ b/src/main/java/com/raisetech/inventoryapi/service/ProductService.java
@@ -1,5 +1,6 @@
 package com.raisetech.inventoryapi.service;
 
+import com.raisetech.inventoryapi.entity.InventoryHistory;
 import com.raisetech.inventoryapi.entity.Product;
 
 import java.util.List;
@@ -14,4 +15,6 @@ public interface ProductService {
     void updateProductById(int id, String name) throws Exception;
 
     void deleteProductById(int id) throws Exception;
+
+    List<InventoryHistory> findHistoriesByProductId(int id);
 }

--- a/src/main/java/com/raisetech/inventoryapi/service/ProductServiceImpl.java
+++ b/src/main/java/com/raisetech/inventoryapi/service/ProductServiceImpl.java
@@ -55,6 +55,7 @@ public class ProductServiceImpl implements ProductService {
 
     @Override
     public List<InventoryHistory> findHistoriesByProductId(int id) {
+        productMapper.findById(id).orElseThrow(() -> new ResourceNotFoundException("resource not found with id: " + id));
         return productMapper.findHistoriesByProductId(id);
     }
 }

--- a/src/main/java/com/raisetech/inventoryapi/service/ProductServiceImpl.java
+++ b/src/main/java/com/raisetech/inventoryapi/service/ProductServiceImpl.java
@@ -1,5 +1,6 @@
 package com.raisetech.inventoryapi.service;
 
+import com.raisetech.inventoryapi.entity.InventoryHistory;
 import com.raisetech.inventoryapi.entity.Product;
 import com.raisetech.inventoryapi.exception.InventoryStillExistsException;
 import com.raisetech.inventoryapi.exception.ResourceNotFoundException;
@@ -50,5 +51,10 @@ public class ProductServiceImpl implements ProductService {
         } else {
             throw new InventoryStillExistsException("Cannot delete Product because the quantity is not 0");
         }
+    }
+
+    @Override
+    public List<InventoryHistory> findHistoriesByProductId(int id) {
+        return productMapper.findHistoriesByProductId(id);
     }
 }

--- a/src/test/java/com/raisetech/inventoryapi/service/ProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/service/ProductServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.raisetech.inventoryapi.service;
 
+import com.raisetech.inventoryapi.entity.InventoryHistory;
 import com.raisetech.inventoryapi.entity.InventoryProduct;
 import com.raisetech.inventoryapi.entity.Product;
 import com.raisetech.inventoryapi.exception.ResourceNotFoundException;
@@ -13,6 +14,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -145,5 +148,18 @@ class ProductServiceImplTest {
         assertThatThrownBy(() -> productServiceImpl.deleteProductById(id))
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessage("resource not found with id: " + id);
+    }
+
+    @Test
+    public void 指定した商品IDの在庫履歴を取得できること() {
+        int inventoryId = 1;
+        int productId = 1;
+        OffsetDateTime dateTime = OffsetDateTime.parse("2023-12-10T23:58:10+09:00");
+        List<InventoryHistory> history = new ArrayList<InventoryHistory>();
+        history.add(new InventoryHistory(inventoryId, productId, "Test", 100, dateTime));
+
+        doReturn(history).when(productMapper).findHistoriesByProductId(productId);
+        List<InventoryHistory> actual = productServiceImpl.findHistoriesByProductId(productId);
+        assertThat(actual).isEqualTo(history);
     }
 }

--- a/src/test/java/com/raisetech/inventoryapi/service/ProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/service/ProductServiceImplTest.java
@@ -163,4 +163,13 @@ class ProductServiceImplTest {
         List<InventoryHistory> actual = productServiceImpl.findHistoriesByProductId(productId);
         assertThat(actual).isEqualTo(history);
     }
+
+    @Test
+    public void 存在しない商品IDで在庫履歴取得時例外を返すこと() {
+        int id = 0;
+        doReturn(Optional.empty()).when(productMapper).findById(id);
+        assertThatThrownBy(() -> productServiceImpl.findHistoriesByProductId(id))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("resource not found with id: " + id);
+    }
 }

--- a/src/test/java/com/raisetech/inventoryapi/service/ProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/service/ProductServiceImplTest.java
@@ -150,13 +150,14 @@ class ProductServiceImplTest {
                 .hasMessage("resource not found with id: " + id);
     }
 
-    @Test
-    public void 指定した商品IDの在庫履歴を取得できること() {
+    @ParameterizedTest
+    @ValueSource(ints = {100, 0})
+    public void 指定した商品IDの在庫履歴を取得できること(int quantity) {
         int inventoryId = 1;
         int productId = 1;
         OffsetDateTime dateTime = OffsetDateTime.parse("2023-12-10T23:58:10+09:00");
         List<InventoryHistory> history = new ArrayList<InventoryHistory>();
-        history.add(new InventoryHistory(inventoryId, productId, "Test", 100, dateTime));
+        history.add(new InventoryHistory(inventoryId, productId, "Test", quantity, dateTime));
 
         doReturn(history).when(productMapper).findHistoriesByProductId(productId);
         List<InventoryHistory> actual = productServiceImpl.findHistoriesByProductId(productId);

--- a/src/test/java/com/raisetech/inventoryapi/service/ProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/service/ProductServiceImplTest.java
@@ -15,7 +15,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -150,14 +149,25 @@ class ProductServiceImplTest {
                 .hasMessage("resource not found with id: " + id);
     }
 
-    @ParameterizedTest
-    @ValueSource(ints = {100, 0})
-    public void 指定した商品IDの在庫履歴を取得できること(int quantity) {
+    @Test
+    public void 指定した商品IDの在庫履歴を取得できること() {
         int inventoryId = 1;
         int productId = 1;
         OffsetDateTime dateTime = OffsetDateTime.parse("2023-12-10T23:58:10+09:00");
-        List<InventoryHistory> history = new ArrayList<InventoryHistory>();
-        history.add(new InventoryHistory(inventoryId, productId, "Test", quantity, dateTime));
+        List<InventoryHistory> history = List.of(new InventoryHistory(inventoryId, productId, "Test", 100, dateTime));
+
+        doReturn(Optional.of(new Product("Test"))).when(productMapper).findById(productId);
+        doReturn(history).when(productMapper).findHistoriesByProductId(productId);
+        List<InventoryHistory> actual = productServiceImpl.findHistoriesByProductId(productId);
+        assertThat(actual).isEqualTo(history);
+    }
+
+    @Test
+    public void 在庫がゼロの時指定した商品IDの在庫履歴を取得できること() {
+        int inventoryId = 1;
+        int productId = 1;
+        OffsetDateTime dateTime = OffsetDateTime.parse("2023-12-10T23:58:10+09:00");
+        List<InventoryHistory> history = List.of(new InventoryHistory(inventoryId, productId, "Test", 0, dateTime));
 
         doReturn(Optional.of(new Product("Test"))).when(productMapper).findById(productId);
         doReturn(history).when(productMapper).findHistoriesByProductId(productId);

--- a/src/test/java/com/raisetech/inventoryapi/service/ProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/service/ProductServiceImplTest.java
@@ -159,6 +159,7 @@ class ProductServiceImplTest {
         List<InventoryHistory> history = new ArrayList<InventoryHistory>();
         history.add(new InventoryHistory(inventoryId, productId, "Test", quantity, dateTime));
 
+        doReturn(Optional.of(new Product("Test"))).when(productMapper).findById(productId);
         doReturn(history).when(productMapper).findHistoriesByProductId(productId);
         List<InventoryHistory> actual = productServiceImpl.findHistoriesByProductId(productId);
         assertThat(actual).isEqualTo(history);


### PR DESCRIPTION
# Serviceの実装とテスト追加

在庫履歴取得機能として#35で実装したmapperに対し、serivceを追加しました。
また、同serivceのテストを追加しました。

* Service/ServiceImplの実装(https://github.com/Kumagai6824/Inventory-API/commit/30289aed8b3fc85448143ba56a85a34f2a23a699)
  * 存在しないID指定時の例外処理追加(https://github.com/Kumagai6824/Inventory-API/pull/36/commits/8b55f079addef6274ba238e8dbb74840fd53b97d)
* ServiceImplTestにて指定した商品IDの在庫履歴を取得できることテスト追加(https://github.com/Kumagai6824/Inventory-API/pull/36/commits/c6765977cbb1d811d663530ddccdb8cd13526daa)
  * 数量がゼロのケースを追加(https://github.com/Kumagai6824/Inventory-API/pull/36/commits/754aff3d0a634d097ea4cb585114a10199e8e063)
  * findByIdの動きの部分を修正(https://github.com/Kumagai6824/Inventory-API/pull/36/commits/b2e0e823aa13a921282e5ceeaacfe349808c1854)
* 〃存在しないID指定時のテスト追加(https://github.com/Kumagai6824/Inventory-API/pull/36/commits/8b15db2ee4d469e15c74fd5c5fc844b38917c494)


※後日実装を考えている点は以下の通りです。追加点が多くなりそうなので、一旦上記まででご確認いただけますと幸いです。
* 論理削除後の在庫履歴取得時のテスト
* 商品は登録済み、在庫は未登録の場合の在庫履歴取得時のサービスの動きの検討（在庫未登録の例外をつくるか、あるいは空データを返す？）