### PR TITLE
Service/論理削除後の在庫履歴取得

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/entity/Product.java
+++ b/src/main/java/com/raisetech/inventoryapi/entity/Product.java
@@ -1,13 +1,12 @@
 package com.raisetech.inventoryapi.entity;
 
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 
 import java.time.OffsetDateTime;
 import java.util.Objects;
 
 @RequiredArgsConstructor
-@Setter
+
 public class Product {
     private int id;
     private String name;
@@ -33,6 +32,10 @@ public class Product {
 
     public OffsetDateTime getDeletedAt() {
         return deletedAt;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     @Override

--- a/src/main/java/com/raisetech/inventoryapi/mapper/ProductMapper.java
+++ b/src/main/java/com/raisetech/inventoryapi/mapper/ProductMapper.java
@@ -14,7 +14,6 @@ public interface ProductMapper {
     List<Product> findAll();
 
     @Select("SELECT * FROM products where id = #{id}")
-    @Result(property = "deletedAt", column = "deleted_at")
     Optional<Product> findById(int id);
 
     @Insert("INSERT INTO products (name) values (#{name})")

--- a/src/main/java/com/raisetech/inventoryapi/mapper/ProductMapper.java
+++ b/src/main/java/com/raisetech/inventoryapi/mapper/ProductMapper.java
@@ -13,7 +13,7 @@ public interface ProductMapper {
     @Result(property = "deletedAt", column = "deleted_at")
     List<Product> findAll();
 
-    @Select("SELECT * FROM products where id = #{id} and deleted_at IS NULL")
+    @Select("SELECT * FROM products where id = #{id}")
     @Result(property = "deletedAt", column = "deleted_at")
     Optional<Product> findById(int id);
 

--- a/src/main/java/com/raisetech/inventoryapi/service/ProductServiceImpl.java
+++ b/src/main/java/com/raisetech/inventoryapi/service/ProductServiceImpl.java
@@ -45,7 +45,12 @@ public class ProductServiceImpl implements ProductService {
 
     @Override
     public void updateProductById(int id, String name) {
-        productMapper.findById(id).orElseThrow(() -> new ResourceNotFoundException("resource not found with id: " + id));
+        Optional<Product> productOptional = productMapper.findById(id);
+
+        Product product = productOptional.orElseThrow(() -> new ResourceNotFoundException("resource not found with id: " + id));
+        if (product.getDeletedAt() != null) {
+            throw new ResourceNotFoundException("resource not found with id: " + id);
+        }
         productMapper.updateProductById(id, name);
     }
 

--- a/src/main/java/com/raisetech/inventoryapi/service/ProductServiceImpl.java
+++ b/src/main/java/com/raisetech/inventoryapi/service/ProductServiceImpl.java
@@ -9,6 +9,7 @@ import com.raisetech.inventoryapi.mapper.ProductMapper;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class ProductServiceImpl implements ProductService {
@@ -27,7 +28,14 @@ public class ProductServiceImpl implements ProductService {
 
     @Override
     public Product findById(int id) {
-        return this.productMapper.findById(id).orElseThrow(() -> new ResourceNotFoundException("Product ID:" + id + " does not exist"));
+        Optional<Product> productOptional = productMapper.findById(id);
+        
+        Product product = productOptional.orElseThrow(() -> new ResourceNotFoundException("Product ID:" + id + " does not exist"));
+        if (product.getDeletedAt() != null) {
+            throw new ResourceNotFoundException("Product ID:" + id + " does not exist");
+        }
+
+        return product;
     }
 
     @Override

--- a/src/main/java/com/raisetech/inventoryapi/service/ProductServiceImpl.java
+++ b/src/main/java/com/raisetech/inventoryapi/service/ProductServiceImpl.java
@@ -29,7 +29,7 @@ public class ProductServiceImpl implements ProductService {
     @Override
     public Product findById(int id) {
         Optional<Product> productOptional = productMapper.findById(id);
-        
+
         Product product = productOptional.orElseThrow(() -> new ResourceNotFoundException("Product ID:" + id + " does not exist"));
         if (product.getDeletedAt() != null) {
             throw new ResourceNotFoundException("Product ID:" + id + " does not exist");
@@ -63,7 +63,6 @@ public class ProductServiceImpl implements ProductService {
 
     @Override
     public List<InventoryHistory> findHistoriesByProductId(int id) {
-        //findByIdでは論理削除したデータは取得されないので、論理削除商品の在庫履歴が見れない
         productMapper.findById(id).orElseThrow(() -> new ResourceNotFoundException("resource not found with id: " + id));
         return productMapper.findHistoriesByProductId(id);
     }

--- a/src/main/java/com/raisetech/inventoryapi/service/ProductServiceImpl.java
+++ b/src/main/java/com/raisetech/inventoryapi/service/ProductServiceImpl.java
@@ -55,6 +55,7 @@ public class ProductServiceImpl implements ProductService {
 
     @Override
     public List<InventoryHistory> findHistoriesByProductId(int id) {
+        //findByIdでは論理削除したデータは取得されないので、論理削除商品の在庫履歴が見れない
         productMapper.findById(id).orElseThrow(() -> new ResourceNotFoundException("resource not found with id: " + id));
         return productMapper.findHistoriesByProductId(id);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.datasource.url=${SPRING_DATASOURCE_URL}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
+mybatis.configuration.map-underscore-to-camel-case=true

--- a/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
@@ -75,14 +75,7 @@ class ProductMapperTest {
         Optional<Product> product2 = productMapper.findById(10);
         assertThat(product2).isEmpty();
     }
-
-    @Test
-    @Transactional
-    void 削除した商品IDを指定したときに空で返すこと() {
-        productMapper.deleteProductById(1);
-        Optional<Product> product = productMapper.findById(1);
-        assertThat(product).isEmpty();
-    }
+    
 
     @Test
     @Sql(

--- a/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/mapper/ProductMapperTest.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.TimeZone;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 
@@ -75,7 +76,7 @@ class ProductMapperTest {
         Optional<Product> product2 = productMapper.findById(10);
         assertThat(product2).isEmpty();
     }
-    
+
 
     @Test
     @Sql(
@@ -101,9 +102,13 @@ class ProductMapperTest {
     @Test
     @Transactional
     void 削除済みレコードを更新しても処理されないこと() {
-        productMapper.deleteProductById(1);
-        productMapper.updateProductById(1, "updatedName");
-        assertThat(productMapper.findById(1)).isEmpty();
+        int productId = 1;
+        String presentName = productMapper.findById(productId).get().getName();
+        productMapper.deleteProductById(productId);
+        productMapper.updateProductById(productId, "updatedName");
+        String nameAfterUpdate = productMapper.findById(productId).get().getName();
+
+        assertEquals(presentName, nameAfterUpdate);
 
     }
 

--- a/src/test/java/com/raisetech/inventoryapi/service/ProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/service/ProductServiceImplTest.java
@@ -189,17 +189,26 @@ class ProductServiceImplTest {
         int inventoryId = 1;
         int productId = 1;
 
-        when(productMapper.findById(productId)).thenReturn(Optional.of(new Product()));
+        Product existingProduct = new Product();
+        existingProduct.setId(productId);
+        existingProduct.setDeletedAt(null);
+
+        when(productMapper.findById(productId)).thenReturn(Optional.of(existingProduct));
 
         productServiceImpl.deleteProductById(productId);
         verify(productMapper).deleteProductById(productId);
 
-        when(productMapper.findById(productId)).thenReturn(Optional.empty());
+        Product deletedProduct = new Product();
+        deletedProduct.setId(productId);
+        deletedProduct.setDeletedAt(OffsetDateTime.now());
+
+        when(productMapper.findById(productId)).thenReturn(Optional.of(deletedProduct));
 
         OffsetDateTime dateTime = OffsetDateTime.parse("2023-12-10T23:58:10+09:00");
-        List<InventoryHistory> history = List.of(new InventoryHistory(inventoryId, productId, "Test", 0, dateTime));
+        List<InventoryHistory> history = List.of(new InventoryHistory(inventoryId, productId, "Test", 100, dateTime));
 
-        doReturn(history).when(productMapper).findHistoriesByProductId(productId);
+        when(productMapper.findHistoriesByProductId(productId)).thenReturn(history);
+
         List<InventoryHistory> actual = productServiceImpl.findHistoriesByProductId(productId);
         assertThat(actual).isEqualTo(history);
     }

--- a/src/test/java/com/raisetech/inventoryapi/service/ProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/service/ProductServiceImplTest.java
@@ -189,20 +189,14 @@ class ProductServiceImplTest {
         int inventoryId = 1;
         int productId = 1;
 
-        Product existingProduct = new Product();
-        existingProduct.setId(productId);
-        existingProduct.setDeletedAt(null);
+        Product existingProduct = new Product(productId, "test", null);
 
         when(productMapper.findById(productId)).thenReturn(Optional.of(existingProduct));
 
         productServiceImpl.deleteProductById(productId);
         verify(productMapper).deleteProductById(productId);
 
-        Product deletedProduct = new Product();
-        deletedProduct.setId(productId);
-        deletedProduct.setDeletedAt(OffsetDateTime.now());
-
-        when(productMapper.findById(productId)).thenReturn(Optional.of(deletedProduct));
+        when(productMapper.findById(productId)).thenReturn(Optional.of(existingProduct));
 
         OffsetDateTime dateTime = OffsetDateTime.parse("2023-12-10T23:58:10+09:00");
         List<InventoryHistory> history = List.of(new InventoryHistory(inventoryId, productId, "Test", 100, dateTime));

--- a/src/test/java/com/raisetech/inventoryapi/service/ProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/service/ProductServiceImplTest.java
@@ -123,21 +123,19 @@ class ProductServiceImplTest {
 
     @Test
     public void 商品を削除した際在庫が0個なら削除されること() throws Exception {
-        int id = 1;
-        Product product = new Product();
-        product.setId(id);
+        int productId = 1;
+        Product product = new Product(productId, "test", null);
 
         int quantity = 0;
-
         InventoryProduct inventoryProduct = new InventoryProduct();
         inventoryProduct.setQuantity(quantity);
 
-        when(productMapper.findById(id)).thenReturn(Optional.of(product));
-        when(inventoryProductMapper.getQuantityByProductId(id)).thenReturn(quantity);
+        when(productMapper.findById(productId)).thenReturn(Optional.of(product));
+        when(inventoryProductMapper.getQuantityByProductId(productId)).thenReturn(quantity);
 
-        productServiceImpl.deleteProductById(id);
+        productServiceImpl.deleteProductById(productId);
 
-        verify(productMapper, times(1)).deleteProductById(id);
+        verify(productMapper, times(1)).deleteProductById(productId);
     }
 
     @Test

--- a/src/test/java/com/raisetech/inventoryapi/service/ProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/service/ProductServiceImplTest.java
@@ -183,4 +183,24 @@ class ProductServiceImplTest {
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessage("resource not found with id: " + id);
     }
+
+    @Test
+    public void 削除済み商品IDで在庫履歴が取得できること() {
+        int inventoryId = 1;
+        int productId = 1;
+
+        when(productMapper.findById(productId)).thenReturn(Optional.of(new Product()));
+
+        productServiceImpl.deleteProductById(productId);
+        verify(productMapper).deleteProductById(productId);
+
+        when(productMapper.findById(productId)).thenReturn(Optional.empty());
+
+        OffsetDateTime dateTime = OffsetDateTime.parse("2023-12-10T23:58:10+09:00");
+        List<InventoryHistory> history = List.of(new InventoryHistory(inventoryId, productId, "Test", 0, dateTime));
+
+        doReturn(history).when(productMapper).findHistoriesByProductId(productId);
+        List<InventoryHistory> actual = productServiceImpl.findHistoriesByProductId(productId);
+        assertThat(actual).isEqualTo(history);
+    }
 }


### PR DESCRIPTION
# 課題

### 実装したい仕様
在庫履歴の取得機能において、
1. 商品と在庫両方が登録されている場合→在庫履歴を取得可能
2. 商品のみ登録されている場合→在庫履歴取得の処理は進められるが、空データを返す（あるいは例外を返す）
3. 上記2パターンにおいて、商品が論理削除されている場合→挙動は上記2パターンと同じとしたい
4. 商品IDが存在しない（論理削除されたわけではなくそもそも登録していないID）場合→例外を返す（ResourceNotFoundException）

### 現状の問題
上記4を実装しようと思い、既に実装済みのfindByIdメソッドを追加したが、findByIdは論理削除されたレコードは取得しない為、上記3の「論理削除された商品の在庫履歴の取得」をしようとすると、ResourceNotFoundExceptionとなる。

d3bf57bcfb74ba325ed5c6674aa297213f444ed5

ProductMapperクラス
```
    @Select("SELECT * FROM products where id = #{id} and deleted_at IS NULL")
    @Result(property = "deletedAt", column = "deleted_at")
    Optional<Product> findById(int id);
```

ProductServiceImplクラス
```
    @Override
    public List<InventoryHistory> findHistoriesByProductId(int id) {
        //存在しないIDかどうかチェックして例外処理を入れたい。
        productMapper.findById(id).orElseThrow(() -> new ResourceNotFoundException("resource not found with id: " + id));

        return productMapper.findHistoriesByProductId(id);
```

### 対応検討
findByIdとは別に、論理削除済レコードを含めて取得するようなメソッドを追加するのはどうか。

ProductMapperクラス
```
    //Sqlにてdeleted_at IS NULLの条件を除き、削除済み商品を含めた全てを取得対象とする
    @Select("SELECT * FROM products where id = #{id}")
    Optional<Product> findAllIncludeDeletedById(int id){
```

ProductServiceImplクラス
```
    @Override
    public List<InventoryHistory> findHistoriesByProductId(int id) {
        //存在しないIDかどうかチェック
        productMapper.findAllIncludeDeletedById(id).orElseThrow(() -> new ResourceNotFoundException("resource not found with id: " + id));

        return productMapper.findHistoriesByProductId(id);
```