### PR TITLE
Controller/在庫履歴取得

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/controller/ProductController.java
+++ b/src/main/java/com/raisetech/inventoryapi/controller/ProductController.java
@@ -68,7 +68,7 @@ public class ProductController {
         return Map.of("message", "Successful operation");
     }
 
-    @GetMapping("/products/histories/{id}")
+    @GetMapping("/products/{id}/histories")
     public List<InventoryHistory> findHistoriesByProductId(
             @PathVariable(value = "id")
             int id) {

--- a/src/main/java/com/raisetech/inventoryapi/controller/ProductController.java
+++ b/src/main/java/com/raisetech/inventoryapi/controller/ProductController.java
@@ -1,5 +1,6 @@
 package com.raisetech.inventoryapi.controller;
 
+import com.raisetech.inventoryapi.entity.InventoryHistory;
 import com.raisetech.inventoryapi.entity.Product;
 import com.raisetech.inventoryapi.form.CreateForm;
 import com.raisetech.inventoryapi.form.UpdateForm;
@@ -35,7 +36,7 @@ public class ProductController {
         return productService.findById(id);
 
     }
-    
+
 
     @PostMapping("/products")
     public ResponseEntity<Map<String, String>> createProduct
@@ -65,6 +66,13 @@ public class ProductController {
             int id) throws Exception {
         productService.deleteProductById(id);
         return Map.of("message", "Successful operation");
+    }
+
+    @GetMapping("/products/histories/{id}")
+    public List<InventoryHistory> findHistoriesByProductId(
+            @PathVariable(value = "id")
+            int id) {
+        return productService.findHistoriesByProductId(id);
     }
 
 

--- a/src/main/java/com/raisetech/inventoryapi/entity/InventoryHistory.java
+++ b/src/main/java/com/raisetech/inventoryapi/entity/InventoryHistory.java
@@ -22,8 +22,21 @@ public class InventoryHistory {
         return id;
     }
 
+    public int getProductId() {
+        return productId;
+    }
+
+
     public String getName() {
         return name;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public OffsetDateTime getHistory() {
+        return history;
     }
 
     @Override

--- a/src/test/java/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/UserRestApiIntegrationTest.java
@@ -388,4 +388,37 @@ public class UserRestApiIntegrationTest {
                 , response, JSONCompareMode.STRICT);
 
     }
+
+    @Test
+    @DataSet(value = {"products.yml", "inventoryProducts.yml"})
+    @Transactional
+    void 削除済み商品IDの在庫履歴を全件取得できること() throws Exception {
+        int productId = 3;
+        mockMvc.perform(MockMvcRequestBuilders.delete("/products/" + productId))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/products/" + productId + "/histories"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                         [
+                            {
+                               "id": 3,
+                               "productId": %s,
+                               "name": "Test",
+                               "quantity": 500,
+                               "history": "2024-05-10T12:58:10+09:00"
+                            },
+                            {
+                               "id": 4,
+                               "productId": %s,
+                               "name": "Test",
+                               "quantity": -500,
+                               "history": "2024-05-11T12:58:10+09:00"
+                            }
+                         ]
+                        """.formatted(productId, productId)
+                , response, JSONCompareMode.STRICT);
+
+    }
 }

--- a/src/test/java/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/UserRestApiIntegrationTest.java
@@ -61,6 +61,11 @@ public class UserRestApiIntegrationTest {
                                "id":2,
                                "name":"Washer",
                                "deletedAt":null
+                            },
+                            {
+                               "id":3,
+                               "name":"Test",
+                               "deletedAt":null
                             }
                          ]           
                         """

--- a/src/test/java/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/UserRestApiIntegrationTest.java
@@ -426,4 +426,18 @@ public class UserRestApiIntegrationTest {
                 , response, JSONCompareMode.STRICT);
 
     }
+
+    @Test
+    @DataSet(value = {"products.yml", "inventoryProducts.yml"})
+    @Transactional
+    void 存在しない商品IDで在庫履歴取得時404を返すこと() throws Exception {
+        int productId = 0;
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/products/" + productId + "/histories"))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        assertEquals("/products/" + productId + "/histories", JsonPath.read(response, "$.path"));
+        assertEquals("Not Found", JsonPath.read(response, "$.error"));
+        assertEquals("resource not found with id: " + productId, JsonPath.read(response, "$.message"));
+    }
 }

--- a/src/test/java/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/UserRestApiIntegrationTest.java
@@ -370,7 +370,7 @@ public class UserRestApiIntegrationTest {
     @DataSet(value = {"products.yml", "inventoryProducts.yml"})
     @Transactional
     void 指定した商品IDの在庫履歴を全件取得できること() throws Exception {
-        String response = mockMvc.perform(MockMvcRequestBuilders.get("/products/histories/1"))
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/products/1/histories"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 

--- a/src/test/java/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/UserRestApiIntegrationTest.java
@@ -365,4 +365,27 @@ public class UserRestApiIntegrationTest {
         assertEquals("Not Found", JsonPath.read(response, "$.error"));
         assertEquals("resource not found with id: " + id, JsonPath.read(response, "$.message"));
     }
+
+    @Test
+    @DataSet(value = {"products.yml", "inventoryProducts.yml"})
+    @Transactional
+    void 指定した商品IDの在庫履歴を全件取得できること() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/products/histories/1"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                         [
+                            {
+                               "id":1,
+                               "productId": 1,
+                               "name": "Bolt 1",
+                               "quantity": 100,
+                               "history": "2023-12-10T23:58:10+09:00"
+                            }
+                         ]
+                        """
+                , response, JSONCompareMode.STRICT);
+
+    }
 }

--- a/src/test/resources/dataset/expectedUpdatedProducts.yml
+++ b/src/test/resources/dataset/expectedUpdatedProducts.yml
@@ -3,3 +3,5 @@ products:
     name: "Shaft"
   - id: 2
     name: "Washer"
+  - id: 3
+    name: "Test"

--- a/src/test/resources/dbunit.yml
+++ b/src/test/resources/dbunit.yml
@@ -2,7 +2,7 @@ cacheConnection: false
 cacheTableNames: false
 properties:
   schema: inventory_database
-caseInsensitiveStrategy: LOWERCASE
+  caseSensitiveTableNames: true
 connectionConfig:
   url: "jdbc:mysql://localhost:3308/inventory_database"
   user: "user"

--- a/src/test/resources/inventoryProducts.yml
+++ b/src/test/resources/inventoryProducts.yml
@@ -7,3 +7,11 @@ inventoryProducts:
     product_id: 2
     quantity: 200
     history: '2024-1-10 12:58:10'
+  - id: 3
+    product_id: 3
+    quantity: 500
+    history: '2024-5-10 12:58:10'
+  - id: 4
+    product_id: 3
+    quantity: -500
+    history: '2024-5-11 12:58:10'

--- a/src/test/resources/inventoryProducts.yml
+++ b/src/test/resources/inventoryProducts.yml
@@ -1,0 +1,9 @@
+inventoryProducts:
+  - id: 1
+    product_id: 1
+    quantity: 100
+    history: '2023-12-10 23:58:10'
+  - id: 2
+    product_id: 2
+    quantity: 200
+    history: '2024-1-10 12:58:10'

--- a/src/test/resources/products.yml
+++ b/src/test/resources/products.yml
@@ -3,3 +3,5 @@ products:
     name: "Bolt 1"
   - id: 2
     name: "Washer"
+  - id: 3
+    name: "Test"


### PR DESCRIPTION
# 概要
在庫履歴取得機能のコントローラーの実装を行いました。
途中でエンドポイントを変更したのは、当初の```/products/histories/{id}```では在庫履歴を在庫IDで検索する際に困る点や、今回の在庫履歴取得機能は商品IDを指定し、在庫履歴を全件取得することから、```/products/{id}/histories```の方が適した命名だと考えたためです。

### ProductControllerクラス
* 在庫履歴取得メソッド追加・InventoryHistoryにてGetter追加(https://github.com/Kumagai6824/Inventory-API/commit/529c97e8b76ca816c82c1f2352e929914803b67c)
* エンドポイントを```/products/{id}/histories```へ変更(https://github.com/Kumagai6824/Inventory-API/pull/38/commits/f8c4a20a172e57fb00b86c351cdd9a265f470540)
  * 参考サイト(https://qiita.com/mserizawa/items/b833e407d89abd21ee72)

### UserRestApiIntegrationTestクラス
* 在庫履歴全件取得テストの追加(https://github.com/Kumagai6824/Inventory-API/commit/161c4504d6fc2ef7d7935a3758ad426cba522627)
* テストの@Datasetとして、InventoryProducts.yml追加(https://github.com/Kumagai6824/Inventory-API/commit/f25d093c0d66a047fad2a5b47027c7318de262a3)
* エンドポイント変更を反映(https://github.com/Kumagai6824/Inventory-API/pull/38/commits/8785b16dc2b2b7d2f30f3d248e6780bf20a49a3b)

IntegrationTestのその他テストメソッドは別途実装します。