### PR TITLE
IP.Mapper/findInventoryByProductId修正2

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/mapper/InventoryProductMapper.java
+++ b/src/main/java/com/raisetech/inventoryapi/mapper/InventoryProductMapper.java
@@ -7,12 +7,11 @@ import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Select;
 
 import java.util.List;
-import java.util.Optional;
 
 @Mapper
 public interface InventoryProductMapper {
     @Select("SELECT * FROM inventoryProducts where product_id = #{product_id}")
-    List<Optional<InventoryProduct>> findInventoryByProductId(int productId);
+    List<InventoryProduct> findInventoryByProductId(int productId);
 
     @Select("SELECT COALESCE(SUM(quantity), 0) FROM inventoryProducts where product_id = #{product_id}")
     Integer getQuantityByProductId(int productId);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
-spring.datasource.url=${SPRING_DATASOURCE_URL}
-spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
-spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
+spring.datasource.url=jdbc:mysql://localhost:3308/inventory_database
+spring.datasource.username=user
+spring.datasource.password=password
 mybatis.configuration.map-underscore-to-camel-case=true
 spring.jpa.show-sql=true
 logging.level.org.mybatis=DEBUG

--- a/src/test/java/com/raisetech/inventoryapi/mapper/InventoryProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/mapper/InventoryProductMapperTest.java
@@ -5,6 +5,7 @@ import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import com.raisetech.inventoryapi.entity.InventoryProduct;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
@@ -13,6 +14,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -37,6 +39,41 @@ class InventoryProductMapperTest {
     @AfterEach
     void tearDown() {
         logCurrentInventoryProducts("After test");
+    }
+
+    @Test
+    @Transactional
+    void 指定した商品IDの在庫情報を取得できること() {
+        int productId = 3;
+        List<InventoryProduct> actualInventoryProducts = inventoryProductMapper.findInventoryByProductId(productId);
+
+        OffsetDateTime dateTime = OffsetDateTime.parse("2024-05-10T12:58:10+09:00");
+        OffsetDateTime dateTime2 = OffsetDateTime.parse("2024-05-11T12:58:10+09:00");
+
+        assertThat(actualInventoryProducts)
+                .hasSize(2)
+                .containsExactly(
+                        new InventoryProduct(3, productId, 500, dateTime),
+                        new InventoryProduct(4, productId, -500, dateTime2)
+                );
+    }
+
+    @Test
+    @Transactional
+    void 指定した商品IDの在庫が未登録のとき空を返すこと() {
+        int productId = 4;
+        List<InventoryProduct> actualInventoryProducts = inventoryProductMapper.findInventoryByProductId(productId);
+        Assertions.assertNotNull(actualInventoryProducts);
+        assertThat(actualInventoryProducts).isEmpty();
+    }
+
+    @Test
+    @Transactional
+    void 存在しない商品IDで在庫取得処理したとき空を返すこと() {
+        int productId = 0;
+        List<InventoryProduct> actualInventoryProducts = inventoryProductMapper.findInventoryByProductId(productId);
+        Assertions.assertNotNull(actualInventoryProducts);
+        assertThat(actualInventoryProducts).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
# 概要
#41 の続きです。findInventoryByProductId（商品IDによる在庫取得）のMapperクラスのメソッドの実装内容の修正とそのテスト追加を行いました。

もともとの実装
```
    @Select("SELECT * FROM inventoryProducts where product_id = #{product_id}")
    List<Optional<InventoryProduct>> findInventoryByProductId(int productId);
```
変更後
``` //List<Optional<T>>をList<T>へ
    @Select("SELECT * FROM inventoryProducts where product_id = #{product_id}")
    List<InventoryProduct> findInventoryByProductId(int productId);
```

* product_idが存在する、しない、存在するが在庫が存在する、しない、など複数のケースが想定されるため、nullの可能性についてご指摘あり
* ```List<Optional<InventoryProduct>>``` での実装を検討しましたが、テスト実装がうまくいかない点、そもそもList<Optional>の構造自体が違和感があるとのご指摘あり
* 今回```List<InventoryProduct>``` で複数のケースでの返却の内容を確認したところemptyで返る点を確認

ご確認をよろしくお願いいたします。

* IP.MapperにてfindInventoryByProductIdの戻り値の型を変更(https://github.com/Kumagai6824/Inventory-API/commit/058eb4d049453602fd3eb12069274c39208a3702)
* IP.MapperTestにてテスト実装(https://github.com/Kumagai6824/Inventory-API/commit/c2cab1bc5bba2ff7e62d42d2346502d0f8b58578)