### PR TITLE
IP.MapperTest/在庫登録非正常テスト

### DIFF
--- a/src/test/java/com/raisetech/inventoryapi/mapper/InventoryProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/mapper/InventoryProductMapperTest.java
@@ -1,6 +1,7 @@
 package com.raisetech.inventoryapi.mapper;
 
 import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import com.raisetech.inventoryapi.entity.InventoryProduct;
 import org.junit.jupiter.api.AfterEach;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @MybatisTest
 @DBRider
@@ -122,6 +125,17 @@ class InventoryProductMapperTest {
         for (Map<String, Object> row : rows) {
             System.out.println(row);
         }
+    }
+
+    @Test
+    @ExpectedDataSet(value = "/inventoryProducts.yml")
+    @Transactional
+    void 存在しない商品IDで在庫登録時登録されないこと() {
+        int productId = 0;
+        InventoryProduct inventoryProduct = new InventoryProduct();
+        inventoryProduct.setProductId(productId);
+        inventoryProduct.setQuantity(500);
+        assertThatThrownBy(() -> inventoryProductMapper.createInventoryProduct(inventoryProduct)).isInstanceOf(DataIntegrityViolationException.class);
     }
 
 }

--- a/src/test/java/com/raisetech/inventoryapi/mapper/InventoryProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/mapper/InventoryProductMapperTest.java
@@ -4,20 +4,16 @@ import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import com.raisetech.inventoryapi.entity.InventoryProduct;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -29,19 +25,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class InventoryProductMapperTest {
     @Autowired
     InventoryProductMapper inventoryProductMapper;
-
-    @Autowired
-    JdbcTemplate jdbcTemplate;
-
-    @BeforeEach
-    void setUp() {
-        logCurrentInventoryProducts("Before test");
-    }
-
-    @AfterEach
-    void tearDown() {
-        logCurrentInventoryProducts("After test");
-    }
 
     @Test
     @Transactional
@@ -117,14 +100,6 @@ class InventoryProductMapperTest {
                 .containsExactly(new InventoryProduct(1, productId, 100, dateTime1),
                         new InventoryProduct(id, productId, 500, dateTime2));
 
-    }
-
-    private void logCurrentInventoryProducts(String phase) {
-        List<Map<String, Object>> rows = jdbcTemplate.queryForList("SELECT * FROM inventoryProducts");
-        System.out.println(phase + " - Current inventoryProducts:");
-        for (Map<String, Object> row : rows) {
-            System.out.println(row);
-        }
     }
 
     @Test


### PR DESCRIPTION
# 概要
在庫登録処理（createInventoryProduct）メソッドのMapperTestで、「存在しない商品IDで在庫登録時登録されないこと」テストを追加しました。
商品ID=0 のとき処理しても、DB登録内容に変更がないことを@ExpectedDataSetを使用し確認しています。
同処理の例外ハンドリングはServiceで実装する考えですが、Mapperでの挙動を検証するため、同テストを実装しました。
102350d74560d101d0bb4217997a32e7378a9a97

#41 でデバッグ用に追加した内容は不要になったため削除しました。
672268dc4a16b9e47e6a716d915821046ba9245b