### PR TITLE
IP.Service/在庫登録（出庫）処理

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/service/InventoryProductService.java
+++ b/src/main/java/com/raisetech/inventoryapi/service/InventoryProductService.java
@@ -7,4 +7,6 @@ public interface InventoryProductService {
 
     void receivingInventoryProduct(InventoryProduct inventoryProduct);
 
+    void shippingInventoryProduct(InventoryProduct inventoryProduct);
+
 }

--- a/src/main/java/com/raisetech/inventoryapi/service/InventoryProductServiceImpl.java
+++ b/src/main/java/com/raisetech/inventoryapi/service/InventoryProductServiceImpl.java
@@ -43,4 +43,23 @@ public class InventoryProductServiceImpl implements InventoryProductService {
         inventoryProductMapper.createInventoryProduct(inventoryProduct);
     }
 
+    @Override
+    public void shippingInventoryProduct(InventoryProduct inventoryProduct) {
+        int quantity = inventoryProduct.getQuantity();
+        if (quantity <= 0) {
+            throw new InvalidInputException("Quantity must be greater than zero");
+        }
+
+        int productId = inventoryProduct.getProductId();
+        Optional<Product> productOptional = productMapper.findById(productId);
+
+        Product product = productOptional.orElseThrow(() -> new ResourceNotFoundException("Product ID:" + productId + " does not exist"));
+        if (product.getDeletedAt() != null) {
+            throw new ResourceNotFoundException("Product ID:" + productId + " does not exist");
+        }
+
+        inventoryProduct.setQuantity(quantity * (-1));
+        inventoryProductMapper.createInventoryProduct(inventoryProduct);
+    }
+
 }

--- a/src/test/java/com/raisetech/inventoryapi/service/InventoryProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/service/InventoryProductServiceImplTest.java
@@ -6,8 +6,10 @@ import com.raisetech.inventoryapi.exception.InvalidInputException;
 import com.raisetech.inventoryapi.exception.ResourceNotFoundException;
 import com.raisetech.inventoryapi.mapper.InventoryProductMapper;
 import com.raisetech.inventoryapi.mapper.ProductMapper;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -87,6 +89,73 @@ class InventoryProductServiceImplTest {
         inventoryProduct.setQuantity(quantity);
 
         assertThatThrownBy(() -> inventoryProductServiceImpl.receivingInventoryProduct(inventoryProduct))
+                .isInstanceOf(InvalidInputException.class)
+                .hasMessage("Quantity must be greater than zero");
+    }
+
+    @Test
+    public void 在庫出庫処理時に在庫が登録されること() throws Exception {
+        int productId = 1;
+        Optional<Product> product = Optional.of(new Product(productId, "test", null));
+
+        int quantity = 1000;
+        InventoryProduct inventoryProduct = new InventoryProduct();
+        inventoryProduct.setProductId(productId);
+        inventoryProduct.setQuantity(quantity);
+
+        doReturn(product).when(productMapper).findById(productId);
+        doNothing().when(inventoryProductMapper).createInventoryProduct(inventoryProduct);
+        inventoryProductServiceImpl.shippingInventoryProduct(inventoryProduct);
+
+        ArgumentCaptor<InventoryProduct> argument = ArgumentCaptor.forClass(InventoryProduct.class);
+        verify(inventoryProductMapper, times(1)).createInventoryProduct(argument.capture());
+        Assertions.assertEquals(quantity * (-1), argument.getValue().getQuantity());
+
+    }
+
+    @Test
+    public void 存在しない商品IDで出庫時に例外をスローすること() throws Exception {
+        int productId = 0;
+
+        int quantity = 1000;
+        InventoryProduct inventoryProduct = new InventoryProduct();
+        inventoryProduct.setProductId(productId);
+        inventoryProduct.setQuantity(quantity);
+
+        doReturn(Optional.empty()).when(productMapper).findById(productId);
+        assertThatThrownBy(() -> inventoryProductServiceImpl.shippingInventoryProduct(inventoryProduct))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Product ID:" + productId + " does not exist");
+
+    }
+
+    @Test
+    public void 論理削除済み商品IDで出庫時に例外をスローすること() throws Exception {
+        int productId = 1;
+        OffsetDateTime deletedDateTime = OffsetDateTime.parse("2024-06-24T10:10:01+09:00");
+        Optional<Product> product = Optional.of(new Product(productId, "test", deletedDateTime));
+
+        int quantity = 1000;
+        InventoryProduct inventoryProduct = new InventoryProduct();
+        inventoryProduct.setProductId(productId);
+        inventoryProduct.setQuantity(quantity);
+
+        doReturn(product).when(productMapper).findById(productId);
+        assertThatThrownBy(() -> inventoryProductServiceImpl.shippingInventoryProduct(inventoryProduct))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Product ID:" + productId + " does not exist");
+
+    }
+
+    @Test
+    public void 数量ゼロ個で出庫時に例外をスローすること() throws Exception {
+        int productId = 1;
+        int quantity = 0;
+        InventoryProduct inventoryProduct = new InventoryProduct();
+        inventoryProduct.setProductId(productId);
+        inventoryProduct.setQuantity(quantity);
+
+        assertThatThrownBy(() -> inventoryProductServiceImpl.shippingInventoryProduct(inventoryProduct))
                 .isInstanceOf(InvalidInputException.class)
                 .hasMessage("Quantity must be greater than zero");
     }


### PR DESCRIPTION
# 概要
出庫処理（数量マイナス・メソッド名にshippingを使用）をサービスクラスにて実装しました。入庫処理と異なる点は、ユーザーが渡した数量にマイナスを掛ける点です。これにより、出庫登録されたレコードの数量はマイナスになり、在庫照会時には減った数量で在庫情報が取得されます。

### shippingInventoryProductメソッドの概要
引数に```InventoryProduct```が渡され、まず商品ID（```productId```）が存在するかをチェック（```findById```メソッド利用）します。商品IDが存在した場合、論理削除されているかチェック（```product.getDeletedAt()```）します。削除されてない場合、数量にマイナスを掛けてセットします。最後にマッパークラスの```createInventoryProduct```を実行します。

* 実装内容
1b3b9e00aa1b4360d8dd0facde5358072107954b
* テスト
e3391841fcb819c6ecb6d47371ca10c4f0a0b8b6
ご確認お願いいたします。