### PR TITLE
Create.IP.Form/在庫登録フォーム

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/form/CreateInventoryProductForm.java
+++ b/src/main/java/com/raisetech/inventoryapi/form/CreateInventoryProductForm.java
@@ -1,0 +1,29 @@
+package com.raisetech.inventoryapi.form;
+
+import com.raisetech.inventoryapi.entity.InventoryProduct;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CreateInventoryProductForm {
+    private int productId;
+    
+    @NotNull
+    @Min(1)
+    private Integer quantity;
+
+    public CreateInventoryProductForm(int productId, Integer quantity) {
+        this.productId = productId;
+        this.quantity = quantity;
+    }
+
+    public InventoryProduct convertToInventoryProductEntity() {
+        InventoryProduct inventoryProduct = new InventoryProduct();
+        inventoryProduct.setProductId(this.productId);
+        inventoryProduct.setQuantity(this.quantity);
+        return inventoryProduct;
+    }
+}

--- a/src/main/java/com/raisetech/inventoryapi/form/CreateInventoryProductForm.java
+++ b/src/main/java/com/raisetech/inventoryapi/form/CreateInventoryProductForm.java
@@ -4,13 +4,11 @@ import com.raisetech.inventoryapi.entity.InventoryProduct;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class CreateInventoryProductForm {
     private int productId;
-    
+
     @NotNull
     @Min(1)
     private Integer quantity;

--- a/src/test/java/com/raisetech/inventoryapi/form/CreateInventoryProductFormTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/form/CreateInventoryProductFormTest.java
@@ -1,0 +1,58 @@
+package com.raisetech.inventoryapi.form;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+public class CreateInventoryProductFormTest {
+    private static Validator validator;
+
+    @BeforeAll
+    public static void setUpValidator() {
+        Locale.setDefault(Locale.JAPAN);
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    public void 数量がゼロのときにバリデーションエラーとなること() {
+        int quantity = 0;
+        CreateInventoryProductForm createInventoryProductForm = new CreateInventoryProductForm(1, quantity);
+        Set<ConstraintViolation<CreateInventoryProductForm>> violations = validator.validate(createInventoryProductForm);
+        assertThat(violations).hasSize(1);
+        assertThat(violations)
+                .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                .containsExactlyInAnyOrder(tuple("quantity", "1 以上の値にしてください"));
+    }
+
+    @Test
+    public void 数量がマイナスのときにバリデーションエラーとなること() {
+        int quantity = -500;
+        CreateInventoryProductForm createInventoryProductForm = new CreateInventoryProductForm(1, quantity);
+        Set<ConstraintViolation<CreateInventoryProductForm>> violations = validator.validate(createInventoryProductForm);
+        assertThat(violations).hasSize(1);
+        assertThat(violations)
+                .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                .containsExactlyInAnyOrder(tuple("quantity", "1 以上の値にしてください"));
+    }
+
+    @Test
+    public void 数量がnullのときにバリデーションエラーとなること() {
+        Integer quantity = null;
+        CreateInventoryProductForm createInventoryProductForm = new CreateInventoryProductForm(1, quantity);
+        Set<ConstraintViolation<CreateInventoryProductForm>> violations = validator.validate(createInventoryProductForm);
+        assertThat(violations).hasSize(1);
+        assertThat(violations)
+                .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                .containsExactlyInAnyOrder(tuple("quantity", "null は許可されていません"));
+    }
+}


### PR DESCRIPTION
# 概要
在庫登録時に受けるフォームを実装しました。今のところ入庫・出庫処理とも共通の登録フォームとして考えています。

### CreateInventoryProductFormクラスの概要
商品ID```int productId```と数量```Integer quantity```の変数を持ちます。バリデーションは、数量に```@NotNull```と```@Min(1)```を付与し、null、空文字、数値ゼロ、マイナスに対してエラーメッセージを出します。商品IDについては、存在しないIDを指定した場合404を返す仕様になっており、本フォームでは特にバリデーション指定していません。

```convertToInventoryProductEntity```メソッドは、今後のコントローラーの実装時にフォームで受け取ったデータをエンティティクラスに変換するため、実装しています。

* 実装内容
bd3820a1413f41871f13517fd25c38e26ccb76d2
* テスト
338f83ce3c357a9708dc10c891cdcf4fadfe78fe

ご確認お願いいたします。