### PR TITLE
IP.Controller/在庫登録（入庫）処理

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/controller/InventoryProductController.java
+++ b/src/main/java/com/raisetech/inventoryapi/controller/InventoryProductController.java
@@ -1,11 +1,14 @@
 package com.raisetech.inventoryapi.controller;
 
+import com.raisetech.inventoryapi.entity.InventoryProduct;
+import com.raisetech.inventoryapi.form.CreateInventoryProductForm;
 import com.raisetech.inventoryapi.service.InventoryProductService;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
 
+import java.net.URI;
 import java.util.Map;
 
 @RestController
@@ -24,5 +27,17 @@ public class InventoryProductController {
             int product_id) {
         Integer quantity = inventoryProductService.getQuantityByProductId(product_id);
         return Map.of("quantity", quantity);
+    }
+
+    @PostMapping("/inventory-products/received-items")
+    public ResponseEntity<Map<String, String>> receivingInventoryProduct
+            (@RequestBody @Validated CreateInventoryProductForm from, UriComponentsBuilder uriComponentsBuilder) {
+        InventoryProduct entity = from.convertToInventoryProductEntity();
+        inventoryProductService.receivingInventoryProduct(entity);
+
+        int id = entity.getId();
+        URI url = uriComponentsBuilder.path("/inventory-products/received-items/" + id).build().toUri();
+        return ResponseEntity.created(url).
+                body(Map.of("message", "item was successfully received"));
     }
 }

--- a/src/test/java/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/UserRestApiIntegrationTest.java
@@ -448,7 +448,7 @@ public class UserRestApiIntegrationTest {
     }
 
     @Test
-    @DataSet(value = {"products.yml", "inventoryProducts.yml"}, executeScriptsBefore = {"reset-inventoryProductId.sql"})
+    @DataSet(value = {"products.yml", "inventoryProducts.yml"}, executeScriptsBefore = {"reset-id.sql", "reset-inventoryProductId.sql"}, cleanBefore = true, transactional = true)
     @ExpectedDataSet(value = "/dataset/expectedReceivedInventoryProducts.yml", ignoreCols = "history")
     @Transactional
     void 入庫処理ができ201を返しレコードが登録されていること() throws Exception {

--- a/src/test/java/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/UserRestApiIntegrationTest.java
@@ -6,6 +6,7 @@ import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import com.jayway.jsonpath.JsonPath;
 import com.raisetech.inventoryapi.Work09Application;
+import com.raisetech.inventoryapi.entity.InventoryProduct;
 import com.raisetech.inventoryapi.entity.Product;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -444,5 +445,79 @@ public class UserRestApiIntegrationTest {
         assertEquals("/products/" + productId + "/histories", JsonPath.read(response, "$.path"));
         assertEquals("Not Found", JsonPath.read(response, "$.error"));
         assertEquals("resource not found with id: " + productId, JsonPath.read(response, "$.message"));
+    }
+
+    @Test
+    @DataSet(value = {"products.yml", "inventoryProducts.yml"}, executeScriptsBefore = {"reset-inventoryProductId.sql"})
+    @ExpectedDataSet(value = "/dataset/expectedReceivedInventoryProducts.yml", ignoreCols = "history")
+    @Transactional
+    void 入庫処理ができ201を返しレコードが登録されていること() throws Exception {
+        InventoryProduct request = new InventoryProduct();
+        request.setProductId(1);
+        request.setQuantity(1000);
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestJson = objectMapper.writeValueAsString(request);
+        String response = mockMvc.perform(MockMvcRequestBuilders.post("/inventory-products/received-items")
+                        .content(requestJson).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andReturn().getResponse().getContentAsString((StandardCharsets.UTF_8));
+
+        JSONAssert.assertEquals("""
+                        {
+                           "message":"item was successfully received"
+                        }
+                        """
+                , response, JSONCompareMode.STRICT);
+    }
+
+    @Transactional
+    @DataSet(value = {"products.yml", "inventoryProducts.yml"})
+    @ParameterizedTest
+    @ValueSource(ints = {0, -500})
+    void 入庫処理時の数量が0以下の場合400を返すこと(int quantity) throws Exception {
+        InventoryProduct request = new InventoryProduct();
+        request.setProductId(1);
+        request.setQuantity(quantity);
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestJson = objectMapper.writeValueAsString(request);
+        String responseActual = mockMvc.perform(MockMvcRequestBuilders.post("/inventory-products/received-items")
+                        .content(requestJson).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        String responseExpected = """
+                {
+                   "status":"BAD_REQUEST",
+                   "message":"Bad request",
+                   "errors":[
+                      {
+                         "field":"quantity",
+                         "message":"must be greater than or equal to 1"
+                      }
+                   ]
+                }
+                """;
+
+        JSONAssert.assertEquals(responseExpected, responseActual, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    @Transactional
+    @DataSet(value = {"products.yml", "inventoryProducts.yml"})
+    void 存在しない商品IDで入庫処理時に404を返すこと() throws Exception {
+        int productId = 0;
+        InventoryProduct request = new InventoryProduct();
+        request.setProductId(productId);
+        request.setQuantity(500);
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestJson = objectMapper.writeValueAsString(request);
+        String response = mockMvc.perform(MockMvcRequestBuilders.post("/inventory-products/received-items")
+                        .content(requestJson).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        assertEquals("/inventory-products/received-items", JsonPath.read(response, "$.path"));
+        assertEquals("Not Found", JsonPath.read(response, "$.error"));
+        assertEquals("Product ID:" + productId + " does not exist", JsonPath.read(response, "$.message"));
     }
 }

--- a/src/test/resources/dataset/expectedReceivedInventoryProducts.yml
+++ b/src/test/resources/dataset/expectedReceivedInventoryProducts.yml
@@ -1,0 +1,22 @@
+inventoryProducts:
+  - id: 1
+    product_id: 1
+    quantity: 100
+    history: '2023-12-10 23:58:10'
+  - id: 2
+    product_id: 2
+    quantity: 200
+    history: '2024-1-10 12:58:10'
+  - id: 3
+    product_id: 3
+    quantity: 500
+    history: '2024-5-10 12:58:10'
+  - id: 4
+    product_id: 3
+    quantity: -500
+    history: '2024-5-11 12:58:10'
+  - id: 5
+    product_id: 1
+    quantity: 1000
+    history: ''
+


### PR DESCRIPTION
# 概要
入庫処理のControllerを実装しました。HTTPリクエスト```POST```で商品ID（```productId```）と入庫したい数量（```quantity```）を渡します。フォームで受け取り、（フォーム内のバリデーションチェックで問題なければ、）サービスへ渡し、処理成功のメッセージを返します。

### エンドポイントについて
```/inventory-products/received-items```
今回、在庫登録処理としては、入庫と出庫があるので、まずは入庫は```/received-items```（入庫される物品というイメージ）にしてみました。本APIでは、商品情報```products```と在庫商品情報```inventoryProducts```の区分けイメージで仕様決めているため、上記エンドポイントの```/inventory-products```を入れましたが、無くても支障がなさそうと認識しています。必要性は微妙だと考えていますが、ご指摘ありましたらお願いします。

* 実装内容
b679eb8476821bf1c15060fa7c421d69a6344654
* テスト
60be321f0bb060aff0127a112298bf55c6e78533
f78caef30e27d3319a0389694805fd8707e49aac