### PR TITLE
IP.Service/出庫時在庫数チェック

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/exception/InventoryProductExceptionHandler.java
+++ b/src/main/java/com/raisetech/inventoryapi/exception/InventoryProductExceptionHandler.java
@@ -39,4 +39,18 @@ public class InventoryProductExceptionHandler {
                 "path", request.getRequestURI());
         return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
     }
+
+    @ExceptionHandler(value = InventoryShortageException.class)
+    public ResponseEntity<Map<String, String>> handleInventoryShortage(
+            InventoryShortageException e, HttpServletRequest request
+    ) {
+
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.CONFLICT.value()),
+                "error", HttpStatus.CONFLICT.getReasonPhrase(),
+                "message", e.getMessage(),
+                "path", request.getRequestURI());
+        return new ResponseEntity(body, HttpStatus.CONFLICT);
+    }
 }

--- a/src/main/java/com/raisetech/inventoryapi/exception/InventoryShortageException.java
+++ b/src/main/java/com/raisetech/inventoryapi/exception/InventoryShortageException.java
@@ -1,0 +1,19 @@
+package com.raisetech.inventoryapi.exception;
+
+public class InventoryShortageException extends RuntimeException {
+    public InventoryShortageException() {
+        super();
+    }
+
+    public InventoryShortageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InventoryShortageException(String message) {
+        super(message);
+    }
+
+    public InventoryShortageException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
# 概要
サービスクラスの出庫処理（```shippingInventoryProduct```）において、在庫数よりも多い出庫数を入力した場合、在庫不足の例外をスローする仕様を追加しました。

### 追加部の概要
出庫数```shippingQuantity```と在庫数```inventoryQuantity```を比較し、出庫数の方が大きい場合、```InventoryShortageException```をスローして、現在庫数をメッセージに表示します。

* 実装
11d793fcff296a6cceb53aace47f4b811cb5579e
8fc722ff4744af4dbcf71936f47149c31d2074f7
* テスト
3fce70e7b0323d69d73f8a216f3aecbb01e2406d