### PR TITLE
IP.Controller/出庫処理

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/controller/InventoryProductController.java
+++ b/src/main/java/com/raisetech/inventoryapi/controller/InventoryProductController.java
@@ -40,4 +40,16 @@ public class InventoryProductController {
         return ResponseEntity.created(url).
                 body(Map.of("message", "item was successfully received"));
     }
+
+    @PostMapping("/inventory-products/shipped-items")
+    public ResponseEntity<Map<String, String>> shippingInventoryProduct
+            (@RequestBody @Validated CreateInventoryProductForm from, UriComponentsBuilder uriComponentsBuilder) {
+        InventoryProduct entity = from.convertToInventoryProductEntity();
+        inventoryProductService.shippingInventoryProduct(entity);
+
+        int id = entity.getId();
+        URI url = uriComponentsBuilder.path("/inventory-products/shipped-items/" + id).build().toUri();
+        return ResponseEntity.created(url).
+                body(Map.of("message", "item was successfully shipped"));
+    }
 }

--- a/src/test/resources/dataset/expectedShippedInventoryProducts.yml
+++ b/src/test/resources/dataset/expectedShippedInventoryProducts.yml
@@ -1,0 +1,22 @@
+inventoryProducts:
+  - id: 1
+    product_id: 1
+    quantity: 100
+    history: '2023-12-10 23:58:10'
+  - id: 2
+    product_id: 2
+    quantity: 200
+    history: '2024-1-10 12:58:10'
+  - id: 3
+    product_id: 3
+    quantity: 500
+    history: '2024-5-10 12:58:10'
+  - id: 4
+    product_id: 3
+    quantity: -500
+    history: '2024-5-11 12:58:10'
+  - id: 5
+    product_id: 1
+    quantity: -50
+    history: ''
+


### PR DESCRIPTION
# 概要
コントローラーに出庫処理を実装しました。HTTPリクエスト```POST```で商品ID（```productId```）と入庫したい数量（```quantity```）を渡します。フォームで受け取り、（フォーム内のバリデーションチェックで問題なければ、）サービスへ渡し、処理成功のメッセージを返します。

### エンドポイント
```/inventory-products/shipped-items```
#48 の入庫と同様に設定しました。```/shipped-items```（出庫される物品というイメージ）です。

* 実装
e2ced3a0f6f3905458202f34384dcb85e8ddb0b3
* テスト
36ed14fef64e1febc98aa258861f596122df74c4