### PR TITLE
openapi/在庫更新処理・在庫削除処理 仕様修正

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -273,22 +273,23 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/404NotFound'
+  /inventory-products/received-items/{id}:
     patch:
       tags:
         - InventoryProducts
-      summary: 商品IDによる在庫情報の更新
-      operationId: patchInventoryItemsByProductId
+      summary: 在庫IDによる在庫数の入庫修正
+      operationId: patchReceivedInventoryItemById
       description: |
-        指定した商品IDと一致する在庫情報を更新する
+        指定した在庫ID（直前の登録分のみ）の数量を入庫数として修正する
       parameters:
-        - name: productId
+        - name: id
           in: path
           required: true
           schema:
             type: integer
           example: 1
       requestBody:
-        description: 登録する部品情報
+        description: 修正する数量
         content:
           application/json:
             schema:
@@ -301,7 +302,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/200OK'
+                  $ref: '#/components/schemas/200UpdatedInventoryProduct'
         '400':
           description: Bad Request
           content:
@@ -309,7 +310,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/400BadRequest'
+                  $ref: '#/components/schemas/400UpdatingCreateInventory'
         '404':
           description: Not Found
           content:
@@ -317,7 +318,71 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/404NotFound'
+                  $ref: '#/components/schemas/404InventoryProduct'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/409ConflictOfUpdateReceivedInventoryProduct'
+  /inventory-products/shipped-items/{id}:
+    patch:
+      tags:
+        - InventoryProducts
+      summary: 在庫IDによる在庫数の出庫修正
+      operationId: patchShippedInventoryItemById
+      description: |
+        指定した在庫ID（直前の登録分のみ）の数量を出庫数として修正する
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          example: 1
+      requestBody:
+        description: 修正する数量
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchRequestBody'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/200UpdatedInventoryProduct'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/400UpdatingCreateInventory'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/404InventoryProduct'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  oneOf:
+                    - $ref: '#/components/schemas/409ConflictOfUpdateShippedInventoryProduct'
+                    - $ref: '#/components/schemas/409ConflictOfShippingInventoryProduct'
     delete:
       tags:
         - InventoryProducts
@@ -510,9 +575,9 @@ components:
     PatchRequestBody:
       type: object
       properties:
-        productName:
-          type: string
-          example: 'Gear assy 1'
+        product_id:
+          type: integer
+          example: 1
         quantity:
           type: integer
           example: 2000
@@ -524,6 +589,14 @@ components:
         message:
           type: string
           example: 'Successful operation'
+    200UpdatedInventoryProduct:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          example: 'Quantity was successfully updated'
     201CreatedProduct:
       type: object
       required:
@@ -606,6 +679,31 @@ components:
                   message:
                     type: string
                     example: 'must be greater than or equal to 1'
+    400UpdatingCreateInventory:
+      type: object
+      required:
+        - status
+        - message
+        - errors
+      properties:
+        status:
+          type: string
+          example: 'BAD_REQUEST'
+        message:
+          type: string
+          example: 'Bad request'
+        errors:
+          type: array
+          items:
+            oneOf:
+              - type: object
+                properties:
+                  field:
+                    type: string
+                    example: 'quantity'
+                  message:
+                    type: string
+                    example: 'must be greater than or equal to 1'
 
     404NotFound:
       type: object
@@ -631,6 +729,34 @@ components:
         message:
           type: string
           example: 'Product ID:0 does not exist'
+        status:
+          type: string
+          example:
+            '404'
+    404InventoryProduct:
+      type: object
+      required:
+        - path
+        - error
+        - timestamp
+        - message
+        - status
+      properties:
+        path:
+          type: string
+          example: '/inventory-products/0'
+        error:
+          type: string
+          example:
+            'Not Found'
+        timestamp:
+          type: string
+          example:
+            '2024-03-26T22:19:19.376914800+09:00[Asia/Tokyo]'
+          format: date-time
+        message:
+          type: string
+          example: 'ID:0 does not exist'
         status:
           type: string
           example:
@@ -691,3 +817,59 @@ components:
         message:
           type: string
           example: 'Inventory shortage, only 10 items left'
+    409ConflictOfUpdateReceivedInventoryProduct:
+      type: object
+      required:
+        - status
+        - path
+        - error
+        - timestamp
+        - message
+      properties:
+        status:
+          type: string
+          example:
+            '409'
+        path:
+          type: string
+          example: '/inventory-products/received-items/1'
+        error:
+          type: string
+          example:
+            'Conflict'
+        timestamp:
+          type: string
+          example:
+            '2024-03-26T22:19:19.376914800+09:00[Asia/Tokyo]'
+          format: date-time
+        message:
+          type: string
+          example: 'Cannot update id: 1 , Only the last update can be altered.'
+    409ConflictOfUpdateShippedInventoryProduct:
+      type: object
+      required:
+        - status
+        - path
+        - error
+        - timestamp
+        - message
+      properties:
+        status:
+          type: string
+          example:
+            '409'
+        path:
+          type: string
+          example: '/inventory-products/shipped-items/1'
+        error:
+          type: string
+          example:
+            'Conflict'
+        timestamp:
+          type: string
+          example:
+            '2024-03-26T22:19:19.376914800+09:00[Asia/Tokyo]'
+          format: date-time
+        message:
+          type: string
+          example: 'Cannot update id: 1 , Only the last update can be altered.'

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -383,15 +383,16 @@ paths:
                   oneOf:
                     - $ref: '#/components/schemas/409ConflictOfUpdateShippedInventoryProduct'
                     - $ref: '#/components/schemas/409ConflictOfShippingInventoryProduct'
+  /inventory-products/{id}:
     delete:
       tags:
         - InventoryProducts
-      summary: 商品IDによる在庫情報の削除
+      summary: 在庫IDによる在庫情報の削除
       operationId: deleteInventoryItemsByProductId
       description: |
-        指定した商品IDと一致する在庫情報を削除する
+        指定した在庫IDと一致する在庫情報（直前の登録分のみ）を削除する
       parameters:
-        - name: productId
+        - name: id
           in: path
           required: true
           schema:
@@ -414,6 +415,14 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/404NotFound'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/409ConflictOfDeleteInventoryProduct'
   /inventory-products/received-items:
     post:
       tags:
@@ -873,3 +882,31 @@ components:
         message:
           type: string
           example: 'Cannot update id: 1 , Only the last update can be altered.'
+    409ConflictOfDeleteInventoryProduct:
+      type: object
+      required:
+        - status
+        - path
+        - error
+        - timestamp
+        - message
+      properties:
+        status:
+          type: string
+          example:
+            '409'
+        path:
+          type: string
+          example: '/inventory-products/1'
+        error:
+          type: string
+          example:
+            'Conflict'
+        timestamp:
+          type: string
+          example:
+            '2024-03-26T22:19:19.376914800+09:00[Asia/Tokyo]'
+          format: date-time
+        message:
+          type: string
+          example: 'Cannot delete id: 1 , Only the last update can be altered.'


### PR DESCRIPTION
# 概要
在庫（InventoryProducts）の修正処理（```PATCH```）と削除処理（```DELETE```）の仕様をこれまでのAPIの仕様に沿う形で修正・変更しました。

### 在庫修正処理の概要
本APIは入庫をプラス、出庫をマイナスの数量で管理し、在庫数はこれら数量を合計しています。よって、在庫修正処理においても、入庫修正と出庫修正の2つの処理へ分けました。また、直前の登録分より古い入出庫数を変更してしまうと、よろしくない（※）ため、修正対象が直近登録分かどうかのチェックをする仕様で考えています。
```
※例えば以下のケースで、1の入庫数を100から50に変更できてしまうと、2 の出庫で足りていたはずの在庫が不足してしまう。
0. 在庫100個
1. 入庫100個（在庫200個）
2. 出庫200個（在庫0個）
```

エンドポイント
入庫修正　```/inventory-products/received-items/{id}```
出庫修正　```/inventory-products/shipped-items/{id}```
いずれも在庫カテゴリーの入庫、出庫に対する修正という意味で上記にしました。

### 在庫削除処理の概要
こちらも同様に直前の登録より古い入出庫レコードを削除してしまうと支障が生じると考え、直前の登録分のみ削除できる仕様で考えています。

エンドポイント
```/inventory-products/{id}```
削除対象は入出庫で分ける必要ないと考え、上記にしました。

API仕様書リンク（今後の更新内容も反映される）
https://kumagai6824.github.io/Inventory-API/swagger/