### PR TITLE
IP.Mapper/商品IDでの最終登録在庫の取得

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/mapper/InventoryProductMapper.java
+++ b/src/main/java/com/raisetech/inventoryapi/mapper/InventoryProductMapper.java
@@ -7,6 +7,7 @@ import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Select;
 
 import java.util.List;
+import java.util.Optional;
 
 @Mapper
 public interface InventoryProductMapper {
@@ -19,4 +20,7 @@ public interface InventoryProductMapper {
     @Insert("INSERT INTO inventoryProducts (product_id, quantity, history) values (#{productId}, #{quantity}, now())")
     @Options(useGeneratedKeys = true, keyProperty = "id")
     void createInventoryProduct(InventoryProduct inventoryProduct);
+
+    @Select("SELECT * FROM inventoryProducts where product_id = #{product_id} ORDER BY id desc LIMIT 1")
+    Optional<InventoryProduct> findLatestIdByProductId(int productId);
 }

--- a/src/main/java/com/raisetech/inventoryapi/mapper/InventoryProductMapper.java
+++ b/src/main/java/com/raisetech/inventoryapi/mapper/InventoryProductMapper.java
@@ -22,5 +22,5 @@ public interface InventoryProductMapper {
     void createInventoryProduct(InventoryProduct inventoryProduct);
 
     @Select("SELECT * FROM inventoryProducts where product_id = #{product_id} ORDER BY id desc LIMIT 1")
-    Optional<InventoryProduct> findLatestIdByProductId(int productId);
+    Optional<InventoryProduct> findLatestInventoryByProductId(int productId);
 }

--- a/src/test/java/com/raisetech/inventoryapi/mapper/InventoryProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/mapper/InventoryProductMapperTest.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -111,6 +112,26 @@ class InventoryProductMapperTest {
         inventoryProduct.setProductId(productId);
         inventoryProduct.setQuantity(500);
         assertThatThrownBy(() -> inventoryProductMapper.createInventoryProduct(inventoryProduct)).isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @Transactional
+    void 指定した商品IDで最後に登録された在庫を返すこと() {
+        int productId = 3;
+        Optional<InventoryProduct> actualInventoryProduct = inventoryProductMapper.findLatestInventoryByProductId(productId);
+
+        OffsetDateTime offsetDateTime = OffsetDateTime.parse("2024-05-11T12:58:10+09:00");
+        Optional<InventoryProduct> expectedInventoryProduct = Optional.of(new InventoryProduct(4, 3, -500, offsetDateTime));
+
+        assertThat(actualInventoryProduct).isEqualTo(expectedInventoryProduct);
+    }
+
+    @Test
+    @Transactional
+    void 存在しない商品IDで最後に登録された在庫取得時に空を返すこと() {
+        int productId = 0;
+        Optional<InventoryProduct> actualInventoryProduct = inventoryProductMapper.findLatestInventoryByProductId(productId);
+        assertThat(actualInventoryProduct).isEmpty();
     }
 
 }


### PR DESCRIPTION
# 概要
マッパーにて、最後に登録された在庫を取得する（商品IDを指定）機能を実装しました。
在庫の修正処理と削除処理で、処理対象が「最後に登録された在庫かどうか」チェックする際に利用する想定です。

### findLatestInventoryByProductIdの概要
商品ID（```productId```）を引数に持ち、商品IDと一致する在庫（```inventoryProducts```）を返します。その際在庫ID（```id```）を降順で1件取得しています。存在しない商品IDを指定した場合にnull を返すので、Optionalを使用し、空を返すようにしています。

* 実装
05593738de8ff66b081fabbbca9c8a2944ad7f3e
5bb02d8173b1c23213282596c9a5cc6eb97d8891
* テスト
00e767e0833eb64782dbe80734f47ee85939bdc4