### PR TITLE
IP.Mapper/在庫更新処理

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/mapper/InventoryProductMapper.java
+++ b/src/main/java/com/raisetech/inventoryapi/mapper/InventoryProductMapper.java
@@ -1,10 +1,7 @@
 package com.raisetech.inventoryapi.mapper;
 
 import com.raisetech.inventoryapi.entity.InventoryProduct;
-import org.apache.ibatis.annotations.Insert;
-import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Options;
-import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.*;
 
 import java.util.List;
 import java.util.Optional;
@@ -23,4 +20,7 @@ public interface InventoryProductMapper {
 
     @Select("SELECT * FROM inventoryProducts where product_id = #{product_id} ORDER BY id desc LIMIT 1")
     Optional<InventoryProduct> findLatestInventoryByProductId(int productId);
+
+    @Update("UPDATE inventoryProducts SET quantity = #{quantity} WHERE id =#{id}")
+    void updateInventoryProductById(int id, int quantity);
 }

--- a/src/test/java/com/raisetech/inventoryapi/mapper/InventoryProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/mapper/InventoryProductMapperTest.java
@@ -134,4 +134,29 @@ class InventoryProductMapperTest {
         assertThat(actualInventoryProduct).isEmpty();
     }
 
+    @Test
+    @Transactional
+    void 指定したIDで更新処理時に在庫数が更新されること() {
+        int id = 1;
+        int quantity = 6000;
+        inventoryProductMapper.updateInventoryProductById(id, quantity);
+
+        int productId = 1;
+        List<InventoryProduct> actualInventoryProducts = inventoryProductMapper.findInventoryByProductId(productId);
+
+        OffsetDateTime offsetDateTime = OffsetDateTime.parse("2023-12-10T23:58:10+09:00");
+        InventoryProduct expectedInventoryProduct = new InventoryProduct(id, productId, quantity, offsetDateTime);
+
+        assertThat(actualInventoryProducts).hasSize(1).containsExactly(expectedInventoryProduct);
+    }
+
+    @Test
+    @ExpectedDataSet(value = "/inventoryProducts.yml")
+    @Transactional
+    void 存在しないIDで更新処理時にDBに変化がないこと() {
+        int id = 0;
+        int quantity = 6000;
+        inventoryProductMapper.updateInventoryProductById(id, quantity);
+    }
+
 }

--- a/src/test/java/com/raisetech/inventoryapi/mapper/InventoryProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/mapper/InventoryProductMapperTest.java
@@ -153,7 +153,7 @@ class InventoryProductMapperTest {
     @Test
     @ExpectedDataSet(value = "/inventoryProducts.yml")
     @Transactional
-    void 存在しないIDで更新処理時にDBに変化がないこと() {
+    void 存在しないIDで更新処理時にinventoryProductsテーブルに変更がないこと() {
         int id = 0;
         int quantity = 6000;
         inventoryProductMapper.updateInventoryProductById(id, quantity);


### PR DESCRIPTION
# 概要
マッパーにて在庫数量を更新（API仕様上は”修正”扱い）するメソッドを実装しました。
API仕様上は入庫修正、出庫修正としており、ロジックはサービスで実装する予定です。

### updateInventoryProductByIdの概要
在庫ID（```id```）と在庫数（```quantity```）を引数にもち、在庫IDと一致する在庫情報の数量を更新します。

* 実装
71f9eb8d30d0313741cb6d6ddaa52d915f92a5af
* テスト
0c6d3bc3779ac55651ece8d166c9fe6e1b9348f9