### PR TITLE
IP.Service/入庫修正処理

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/service/InventoryProductService.java
+++ b/src/main/java/com/raisetech/inventoryapi/service/InventoryProductService.java
@@ -9,4 +9,5 @@ public interface InventoryProductService {
 
     void shippingInventoryProduct(InventoryProduct inventoryProduct);
 
+    void updateReceivedInventoryProductById(int productId, int id, int quantity);
 }

--- a/src/main/java/com/raisetech/inventoryapi/service/InventoryProductServiceImpl.java
+++ b/src/main/java/com/raisetech/inventoryapi/service/InventoryProductServiceImpl.java
@@ -69,4 +69,24 @@ public class InventoryProductServiceImpl implements InventoryProductService {
         inventoryProductMapper.createInventoryProduct(inventoryProduct);
     }
 
+    @Override
+    public void updateReceivedInventoryProductById(int productId, int id, int quantity) {
+        Optional<Product> productOptional = productMapper.findById(productId);
+        Product product = productOptional.orElseThrow(() -> new ResourceNotFoundException("Product ID:" + productId + " does not exist"));
+        if (product.getDeletedAt() != null) {
+            throw new ResourceNotFoundException("Product ID:" + productId + " does not exist");
+        }
+
+        Optional<InventoryProduct> inventoryProductOptional = inventoryProductMapper.findLatestInventoryByProductId(productId);
+        InventoryProduct latestInventoryProduct = inventoryProductOptional.orElseThrow(() -> new ResourceNotFoundException("Inventory item does not exist"));
+
+        if (latestInventoryProduct.getId() != id) {
+            throw new InvalidInputException("Cannot update id: " + id + ", Only the last update can be altered.");
+        } else if (quantity <= 0) {
+            throw new InvalidInputException("Quantity must be greater than zero");
+        }
+
+        inventoryProductMapper.updateInventoryProductById(id, quantity);
+    }
+
 }

--- a/src/test/java/com/raisetech/inventoryapi/service/InventoryProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/service/InventoryProductServiceImplTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.OffsetDateTime;
 import java.util.Optional;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
@@ -182,5 +183,100 @@ class InventoryProductServiceImplTest {
         assertThatThrownBy(() -> inventoryProductServiceImpl.shippingInventoryProduct(inventoryProduct))
                 .isInstanceOf(InventoryShortageException.class)
                 .hasMessage("Inventory shortage, only " + inventoryQuantity + " items left");
+    }
+
+    @Test
+    public void 入庫修正後に入庫数が更新されること() throws Exception {
+        int productId = 1;
+        doReturn(Optional.of(new Product(productId, "test", null))).when(productMapper).findById(productId);
+
+        int id = 1;
+        int inventoryQuantity = 100;
+        OffsetDateTime offsetDateTime = OffsetDateTime.parse("2024-06-24T10:10:01+09:00");
+        doReturn(Optional.of(new InventoryProduct(id, productId, inventoryQuantity, offsetDateTime))).when(inventoryProductMapper).findLatestInventoryByProductId(productId);
+
+        int updatingQuantity = 250;
+        inventoryProductServiceImpl.updateReceivedInventoryProductById(productId, id, updatingQuantity);
+
+        ArgumentCaptor<Integer> idCaptor = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Integer> quantityCaptor = ArgumentCaptor.forClass(Integer.class);
+
+        verify(inventoryProductMapper, times(1)).updateInventoryProductById(idCaptor.capture(), quantityCaptor.capture());
+        assertThat(idCaptor.getValue()).isEqualTo(id);
+        assertThat(quantityCaptor.getValue()).isEqualTo(updatingQuantity);
+    }
+
+    @Test
+    public void 存在しない商品IDで入庫修正時に例外を返すこと() throws Exception {
+        int productId = 0;
+        int id = 1;
+        int quantity = 6000;
+
+        doReturn(Optional.empty()).when(productMapper).findById(productId);
+
+        assertThatThrownBy(() -> inventoryProductServiceImpl.updateReceivedInventoryProductById(productId, id, quantity))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Product ID:" + productId + " does not exist");
+    }
+
+    @Test
+    public void 論理削除済み商品IDで入庫修正時に例外を返すこと() throws Exception {
+        int productId = 1;
+        int id = 1;
+        int quantity = 100;
+        OffsetDateTime offsetDateTime = OffsetDateTime.parse("2024-06-24T10:10:01+09:00");
+        doReturn(Optional.of(new Product(productId, "test", offsetDateTime))).when(productMapper).findById(productId);
+
+        assertThatThrownBy(() -> inventoryProductServiceImpl.updateReceivedInventoryProductById(productId, id, quantity))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Product ID:" + productId + " does not exist");
+    }
+
+    @Test
+    public void 指定した商品IDの在庫情報が未登録の状態で入庫修正時に例外を返すこと() throws Exception {
+        int productId = 1;
+        doReturn(Optional.of(new Product(productId, "test", null))).when(productMapper).findById(productId);
+
+        doReturn(Optional.empty()).when(inventoryProductMapper).findLatestInventoryByProductId(productId);
+
+        int id = 1;
+        int quantity = 100;
+        assertThatThrownBy(() -> inventoryProductServiceImpl.updateReceivedInventoryProductById(productId, id, quantity))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Inventory item does not exist");
+    }
+
+    @Test
+    public void 最新ではない在庫IDで入庫修正時に例外を返すこと() throws Exception {
+        int productId = 1;
+        doReturn(Optional.of(new Product(productId, "test", null))).when(productMapper).findById(productId);
+
+        int latestId = 2;
+        int inventoryQuantity = 100;
+        OffsetDateTime offsetDateTime = OffsetDateTime.parse("2024-06-24T10:10:01+09:00");
+        doReturn(Optional.of(new InventoryProduct(latestId, productId, inventoryQuantity, offsetDateTime))).when(inventoryProductMapper).findLatestInventoryByProductId(productId);
+
+        int requestId = 1;
+        int requestQuantity = 250;
+        assertThatThrownBy(() -> inventoryProductServiceImpl.updateReceivedInventoryProductById(productId, requestId, requestQuantity))
+                .isInstanceOf(InvalidInputException.class)
+                .hasMessage("Cannot update id: " + requestId + ", Only the last update can be altered.");
+    }
+
+    @Test
+    public void 数量ゼロ個で入庫修正時に例外をスローすること() throws Exception {
+        int productId = 1;
+        doReturn(Optional.of(new Product(productId, "test", null))).when(productMapper).findById(productId);
+
+        int id = 1;
+        int inventoryQuantity = 100;
+        OffsetDateTime offsetDateTime = OffsetDateTime.parse("2024-06-24T10:10:01+09:00");
+        doReturn(Optional.of(new InventoryProduct(id, productId, inventoryQuantity, offsetDateTime))).when(inventoryProductMapper).findLatestInventoryByProductId(productId);
+
+
+        int requestQuantity = 0;
+        assertThatThrownBy(() -> inventoryProductServiceImpl.updateReceivedInventoryProductById(productId, id, requestQuantity))
+                .isInstanceOf(InvalidInputException.class)
+                .hasMessage("Quantity must be greater than zero");
     }
 }


### PR DESCRIPTION
# 概要
在庫ID、商品ID、数量を指定して、入庫処理数を修正する機能を実装しました。
この機能を使うシーンとしては、在庫の誤登録の修正、を想定しています。
通常の入庫処理と異なる点は、修正対象の在庫が、最後に登録された在庫かどうか（同商品ID内）をチェックする点です。（理由は #53 に記載）

### updateReceivedInventoryProductByIdの概要
引数に商品ID(```productId```）、在庫ID（```id```）、数量（```quantity```）をもちます。
以下のチェックを行い、例外を投げます。

1. 指定した商品IDが存在しなければ```ResourceNotFoundException```を投げます
2. 指定した商品IDが論理削除済みであれば〃例外を投げます
3. 商品は存在し、在庫が存在しない（未登録）であれば〃例外を投げます
4. 在庫IDが、最後に登録された在庫でなければ```InvalidInputException```を投げます
5. 指定した数量がゼロ個以下であれば〃例外を投げます。

上記チェックで該当しなければ、マッパーに在庫IDと数量を渡します。

* 実装
f8bc7ece1b93508335d5e8d387426852da357d00
* テスト
8f2c4d5c9ebb804db3b16bfa81fea44a25f5690c