### PR TITLE
Update.IP.From/在庫更新処理用フォーム

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/form/UpdateInventoryProductForm.java
+++ b/src/main/java/com/raisetech/inventoryapi/form/UpdateInventoryProductForm.java
@@ -1,0 +1,27 @@
+package com.raisetech.inventoryapi.form;
+
+import com.raisetech.inventoryapi.entity.InventoryProduct;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class UpdateInventoryProductForm {
+    private int productId;
+
+    @NotNull
+    @Min(1)
+    private Integer quantity;
+
+    public UpdateInventoryProductForm(int productId, Integer quantity) {
+        this.productId = productId;
+        this.quantity = quantity;
+    }
+
+    public InventoryProduct convertToInventoryProductEntity() {
+        InventoryProduct inventoryProduct = new InventoryProduct();
+        inventoryProduct.setProductId(this.productId);
+        inventoryProduct.setQuantity(this.quantity);
+        return inventoryProduct;
+    }
+}

--- a/src/main/java/com/raisetech/inventoryapi/form/UpdateInventoryProductForm.java
+++ b/src/main/java/com/raisetech/inventoryapi/form/UpdateInventoryProductForm.java
@@ -1,8 +1,8 @@
 package com.raisetech.inventoryapi.form;
 
 import com.raisetech.inventoryapi.entity.InventoryProduct;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 
 @Getter
@@ -10,7 +10,7 @@ public class UpdateInventoryProductForm {
     private int productId;
 
     @NotNull
-    @Min(1)
+    @Positive
     private Integer quantity;
 
     public UpdateInventoryProductForm(int productId, Integer quantity) {

--- a/src/test/java/com/raisetech/inventoryapi/form/UpdateInventoryProductFormTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/form/UpdateInventoryProductFormTest.java
@@ -31,7 +31,7 @@ public class UpdateInventoryProductFormTest {
         assertThat(violations).hasSize(1);
         assertThat(violations)
                 .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
-                .containsExactlyInAnyOrder(tuple("quantity", "1 以上の値にしてください"));
+                .containsExactlyInAnyOrder(tuple("quantity", "0 より大きな値にしてください"));
     }
 
     @Test
@@ -42,7 +42,7 @@ public class UpdateInventoryProductFormTest {
         assertThat(violations).hasSize(1);
         assertThat(violations)
                 .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
-                .containsExactlyInAnyOrder(tuple("quantity", "1 以上の値にしてください"));
+                .containsExactlyInAnyOrder(tuple("quantity", "0 より大きな値にしてください"));
     }
 
     @Test

--- a/src/test/java/com/raisetech/inventoryapi/form/UpdateInventoryProductFormTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/form/UpdateInventoryProductFormTest.java
@@ -1,0 +1,66 @@
+package com.raisetech.inventoryapi.form;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+public class UpdateInventoryProductFormTest {
+    private static Validator validator;
+
+    @BeforeAll
+    public static void setUpValidator() {
+        Locale.setDefault(Locale.JAPAN);
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    public void 数量がゼロのときにバリデーションエラーとなること() {
+        int quantity = 0;
+        UpdateInventoryProductForm updateInventoryProductForm = new UpdateInventoryProductForm(1, quantity);
+        Set<ConstraintViolation<UpdateInventoryProductForm>> violations = validator.validate(updateInventoryProductForm);
+        assertThat(violations).hasSize(1);
+        assertThat(violations)
+                .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                .containsExactlyInAnyOrder(tuple("quantity", "1 以上の値にしてください"));
+    }
+
+    @Test
+    public void 数量がマイナスのときにバリデーションエラーとなること() {
+        int quantity = -500;
+        UpdateInventoryProductForm updateInventoryProductForm = new UpdateInventoryProductForm(1, quantity);
+        Set<ConstraintViolation<UpdateInventoryProductForm>> violations = validator.validate(updateInventoryProductForm);
+        assertThat(violations).hasSize(1);
+        assertThat(violations)
+                .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                .containsExactlyInAnyOrder(tuple("quantity", "1 以上の値にしてください"));
+    }
+
+    @Test
+    public void 数量がnullのときにバリデーションエラーとなること() {
+        Integer quantity = null;
+        UpdateInventoryProductForm updateInventoryProductForm = new UpdateInventoryProductForm(1, quantity);
+        Set<ConstraintViolation<UpdateInventoryProductForm>> violations = validator.validate(updateInventoryProductForm);
+        assertThat(violations).hasSize(1);
+        assertThat(violations)
+                .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                .containsExactlyInAnyOrder(tuple("quantity", "null は許可されていません"));
+    }
+
+    @Test
+    public void 数量が正の整数のときにバリデーションエラーとならないこと() {
+        int quantity = 500;
+        UpdateInventoryProductForm updateInventoryProductForm = new UpdateInventoryProductForm(1, quantity);
+        Set<ConstraintViolation<UpdateInventoryProductForm>> violations = validator.validate(updateInventoryProductForm);
+        assertThat(violations).isEmpty();
+    }
+}


### PR DESCRIPTION
# 概要
在庫更新処理（在庫修正処理）時に受ける、フォームを実装しました。

### UpdateInventoryProductFormの概要
フィールド変数として、商品ID```productId```と数量```qunatity```を持ちます。数量は```@NotNull```と```@Min(1)```を付与し、nullの場合と0以下の数値の場合にバリデーションエラーを出す仕様にしています。商品IDはサービスクラスにて存在しないIDを指定した場合404を返す仕様にしており、フォームでのバリデーションチェックは入れていません。

```convertToInventoryProductEntity```メソッドは、コントローラークラスでエンティティとして利用するためにフォームに渡された値をエンティティに変換します。

* 実装
0c4d1d77c8350808ffa7d9198cc57a4397adf20a
* テスト
61d381c165c02d01dd75bb4a0f85e4086d6b17c4