### PR TITLE
IP.Service例外/入庫修正処理

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/exception/InventoryNotLatestException.java
+++ b/src/main/java/com/raisetech/inventoryapi/exception/InventoryNotLatestException.java
@@ -1,0 +1,19 @@
+package com.raisetech.inventoryapi.exception;
+
+public class InventoryNotLatestException extends RuntimeException {
+    public InventoryNotLatestException() {
+        super();
+    }
+
+    public InventoryNotLatestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InventoryNotLatestException(String message) {
+        super(message);
+    }
+
+    public InventoryNotLatestException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/raisetech/inventoryapi/exception/InventoryProductExceptionHandler.java
+++ b/src/main/java/com/raisetech/inventoryapi/exception/InventoryProductExceptionHandler.java
@@ -53,4 +53,18 @@ public class InventoryProductExceptionHandler {
                 "path", request.getRequestURI());
         return new ResponseEntity(body, HttpStatus.CONFLICT);
     }
+
+    @ExceptionHandler(value = InventoryNotLatestException.class)
+    public ResponseEntity<Map<String, String>> handleInventoryNotLatest(
+            InventoryNotLatestException e, HttpServletRequest request
+    ) {
+
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.CONFLICT.value()),
+                "error", HttpStatus.CONFLICT.getReasonPhrase(),
+                "message", e.getMessage(),
+                "path", request.getRequestURI());
+        return new ResponseEntity(body, HttpStatus.CONFLICT);
+    }
 }

--- a/src/main/java/com/raisetech/inventoryapi/service/InventoryProductServiceImpl.java
+++ b/src/main/java/com/raisetech/inventoryapi/service/InventoryProductServiceImpl.java
@@ -3,6 +3,7 @@ package com.raisetech.inventoryapi.service;
 import com.raisetech.inventoryapi.entity.InventoryProduct;
 import com.raisetech.inventoryapi.entity.Product;
 import com.raisetech.inventoryapi.exception.InvalidInputException;
+import com.raisetech.inventoryapi.exception.InventoryNotLatestException;
 import com.raisetech.inventoryapi.exception.InventoryShortageException;
 import com.raisetech.inventoryapi.exception.ResourceNotFoundException;
 import com.raisetech.inventoryapi.mapper.InventoryProductMapper;
@@ -81,7 +82,7 @@ public class InventoryProductServiceImpl implements InventoryProductService {
         InventoryProduct latestInventoryProduct = inventoryProductOptional.orElseThrow(() -> new ResourceNotFoundException("Inventory item does not exist"));
 
         if (latestInventoryProduct.getId() != id) {
-            throw new InvalidInputException("Cannot update id: " + id + ", Only the last update can be altered.");
+            throw new InventoryNotLatestException("Cannot update id: " + id + ", Only the last update can be altered.");
         } else if (quantity <= 0) {
             throw new InvalidInputException("Quantity must be greater than zero");
         }

--- a/src/test/java/com/raisetech/inventoryapi/service/InventoryProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/service/InventoryProductServiceImplTest.java
@@ -3,6 +3,7 @@ package com.raisetech.inventoryapi.service;
 import com.raisetech.inventoryapi.entity.InventoryProduct;
 import com.raisetech.inventoryapi.entity.Product;
 import com.raisetech.inventoryapi.exception.InvalidInputException;
+import com.raisetech.inventoryapi.exception.InventoryNotLatestException;
 import com.raisetech.inventoryapi.exception.InventoryShortageException;
 import com.raisetech.inventoryapi.exception.ResourceNotFoundException;
 import com.raisetech.inventoryapi.mapper.InventoryProductMapper;
@@ -259,7 +260,7 @@ class InventoryProductServiceImplTest {
         int requestId = 1;
         int requestQuantity = 250;
         assertThatThrownBy(() -> inventoryProductServiceImpl.updateReceivedInventoryProductById(productId, requestId, requestQuantity))
-                .isInstanceOf(InvalidInputException.class)
+                .isInstanceOf(InventoryNotLatestException.class)
                 .hasMessage("Cannot update id: " + requestId + ", Only the last update can be altered.");
     }
 


### PR DESCRIPTION
# 概要
サービスクラスにて、入庫処理時の例外処理をAPI仕様書に合わせ修正しました。
新たに```InventoryNotLatestException```クラスを実装しました。

### 変更内容
* 旧：```InvalidInputException```　HTTPレスポンス400を返す
* 変更後：```InventoryNotLatestException```　409を返す

API仕様書
https://kumagai6824.github.io/Inventory-API/swagger/

* 実装
b52ae7a2c1752adfc63994b5a984385ff4c0f546
03e1740ce5ce08f719ab619984d9ae8ac0892bec
* テスト
472902d5fe4ce6667342f9c92104a3c7b8b983d3