### PR TITLE
IP.Controller/入庫修正処理

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/controller/InventoryProductController.java
+++ b/src/main/java/com/raisetech/inventoryapi/controller/InventoryProductController.java
@@ -2,6 +2,7 @@ package com.raisetech.inventoryapi.controller;
 
 import com.raisetech.inventoryapi.entity.InventoryProduct;
 import com.raisetech.inventoryapi.form.CreateInventoryProductForm;
+import com.raisetech.inventoryapi.form.UpdateInventoryProductForm;
 import com.raisetech.inventoryapi.service.InventoryProductService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -51,5 +52,15 @@ public class InventoryProductController {
         URI url = uriComponentsBuilder.path("/inventory-products/shipped-items/" + id).build().toUri();
         return ResponseEntity.created(url).
                 body(Map.of("message", "item was successfully shipped"));
+    }
+
+    @PatchMapping("/inventory-products/received-items/{id}")
+    public ResponseEntity<Map<String, String>> updateReceivedInventoryProductById
+            (@RequestBody @Validated UpdateInventoryProductForm form,
+             @PathVariable(value = "id") int id) throws Exception {
+        InventoryProduct entity = form.convertToInventoryProductEntity();
+        inventoryProductService.updateReceivedInventoryProductById(entity.getProductId(), id, entity.getQuantity());
+        return ResponseEntity.ok(Map.of("message", "Quantity was successfully updated"));
+
     }
 }

--- a/src/test/resources/dataset/expectedUpdatedReceivedInventoryProducts.yml
+++ b/src/test/resources/dataset/expectedUpdatedReceivedInventoryProducts.yml
@@ -1,0 +1,17 @@
+inventoryProducts:
+  - id: 1
+    product_id: 1
+    quantity: 800
+    history: '2023-12-10 23:58:10'
+  - id: 2
+    product_id: 2
+    quantity: 200
+    history: '2024-1-10 12:58:10'
+  - id: 3
+    product_id: 3
+    quantity: 500
+    history: '2024-5-10 12:58:10'
+  - id: 4
+    product_id: 3
+    quantity: -500
+    history: '2024-5-11 12:58:10'


### PR DESCRIPTION
# 概要
入庫修正処理のControllerを実装しました。HTTPリクエスト```PATCH```でパス変数に最新の登録在庫ID```ID```を指定し、商品ID```productId```と入庫として修正したい数量```quantity```を渡します。フォームで受け取り、（フォーム内のバリデーションチェックで問題なければ、）サービスへ渡し、処理成功のメッセージを返します。

* 実装
9230a276e81ea1f3076d026894256ddf7db1fe09
* テスト
c31e17ed5eb206594fede60180337a4d4710a12f

### 実行結果（正常処理時）
#### inventoryProductsの登録状況
```在庫id : 6```の数量は```500```
![image](https://github.com/user-attachments/assets/672eb925-d40c-4950-beba-1e7292f16823)

#### 入庫修正
```在庫id : 6```の数量を```900```へ、更新が正常に行われたことのメッセージが返る
![image](https://github.com/user-attachments/assets/d5b25aae-05ff-48ae-8847-3a9497d626ee)

#### inventoryProductsの登録状況（入庫修正後）
```在庫id : 6```の数量は```900```となった
![image](https://github.com/user-attachments/assets/694b493e-2888-42c7-90a4-f6d253d3a1a4)

### 実行結果（非正常処理時 ※新規性のある「最後に登録された在庫かどうかのチェック」部分のみ）
#### inventoryProductsの登録状況
上記、入庫修正後の状態と同じ

#### 入庫修正
```在庫id : 5```を数量```5500```へ修正するリクエストを実施
最新の登録在庫IDでないと更新できない旨メッセージが返る
![image](https://github.com/user-attachments/assets/2a964b8a-448c-414e-9797-fb83ad2039c7)
