### PR TITLE
IP.Service/出庫修正処理

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/service/InventoryProductService.java
+++ b/src/main/java/com/raisetech/inventoryapi/service/InventoryProductService.java
@@ -10,4 +10,6 @@ public interface InventoryProductService {
     void shippingInventoryProduct(InventoryProduct inventoryProduct);
 
     void updateReceivedInventoryProductById(int productId, int id, int quantity);
+
+    void updateShippedInventoryProductById(int productId, int id, int quantity);
 }

--- a/src/main/java/com/raisetech/inventoryapi/service/InventoryProductServiceImpl.java
+++ b/src/main/java/com/raisetech/inventoryapi/service/InventoryProductServiceImpl.java
@@ -109,7 +109,7 @@ public class InventoryProductServiceImpl implements InventoryProductService {
         } else if (quantity <= 0) {
             throw new InvalidInputException("Quantity must be greater than zero");
         } else if (quantity > inventoryQuantity - lastUpdatedQuantity) {
-            throw new InventoryShortageException("Inventory shortage, only " + inventoryQuantity + " items left");
+            throw new InventoryShortageException("Inventory shortage, only " + (inventoryQuantity - lastUpdatedQuantity) + " items left");
         }
 
         inventoryProductMapper.updateInventoryProductById(id, quantity * (-1));

--- a/src/main/java/com/raisetech/inventoryapi/service/InventoryProductServiceImpl.java
+++ b/src/main/java/com/raisetech/inventoryapi/service/InventoryProductServiceImpl.java
@@ -102,12 +102,13 @@ public class InventoryProductServiceImpl implements InventoryProductService {
         InventoryProduct latestInventoryProduct = inventoryProductOptional.orElseThrow(() -> new ResourceNotFoundException("Inventory item does not exist"));
 
         int inventoryQuantity = this.inventoryProductMapper.getQuantityByProductId(productId);
+        int lastUpdatedQuantity = latestInventoryProduct.getQuantity();
 
         if (latestInventoryProduct.getId() != id) {
             throw new InventoryNotLatestException("Cannot update id: " + id + ", Only the last update can be altered.");
         } else if (quantity <= 0) {
             throw new InvalidInputException("Quantity must be greater than zero");
-        } else if (quantity > inventoryQuantity) {
+        } else if (quantity > inventoryQuantity - lastUpdatedQuantity) {
             throw new InventoryShortageException("Inventory shortage, only " + inventoryQuantity + " items left");
         }
 

--- a/src/test/java/com/raisetech/inventoryapi/service/InventoryProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/service/InventoryProductServiceImplTest.java
@@ -384,13 +384,14 @@ class InventoryProductServiceImplTest {
         doReturn(Optional.of(new Product(productId, "test", null))).when(productMapper).findById(productId);
 
         int id = 1;
-        int inventoryQuantity = 500;
+        int lastUpdatedQuantity = 400;
         OffsetDateTime offsetDateTime = OffsetDateTime.parse("2024-06-24T10:10:01+09:00");
-        doReturn(Optional.of(new InventoryProduct(id, productId, inventoryQuantity, offsetDateTime))).when(inventoryProductMapper).findLatestInventoryByProductId(productId);
+        doReturn(Optional.of(new InventoryProduct(id, productId, lastUpdatedQuantity, offsetDateTime))).when(inventoryProductMapper).findLatestInventoryByProductId(productId);
 
+        int inventoryQuantity = 500;
         doReturn(inventoryQuantity).when(inventoryProductMapper).getQuantityByProductId(productId);
 
-        int requestQuantity = inventoryQuantity + 100;
+        int requestQuantity = inventoryQuantity - lastUpdatedQuantity + 10;
         assertThatThrownBy(() -> inventoryProductServiceImpl.updateShippedInventoryProductById(productId, id, requestQuantity))
                 .isInstanceOf(InventoryShortageException.class)
                 .hasMessage("Inventory shortage, only " + inventoryQuantity + " items left");

--- a/src/test/java/com/raisetech/inventoryapi/service/InventoryProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/service/InventoryProductServiceImplTest.java
@@ -287,10 +287,11 @@ class InventoryProductServiceImplTest {
         doReturn(Optional.of(new Product(productId, "test", null))).when(productMapper).findById(productId);
 
         int id = 1;
-        int inventoryQuantity = 500;
+        int lastUpdatedQuantity = 500;
         OffsetDateTime offsetDateTime = OffsetDateTime.parse("2024-06-24T10:10:01+09:00");
-        doReturn(Optional.of(new InventoryProduct(id, productId, inventoryQuantity, offsetDateTime))).when(inventoryProductMapper).findLatestInventoryByProductId(productId);
+        doReturn(Optional.of(new InventoryProduct(id, productId, lastUpdatedQuantity, offsetDateTime))).when(inventoryProductMapper).findLatestInventoryByProductId(productId);
 
+        int inventoryQuantity = 800;
         doReturn(inventoryQuantity).when(inventoryProductMapper).getQuantityByProductId(productId);
 
         int updatingQuantity = 100;
@@ -394,7 +395,7 @@ class InventoryProductServiceImplTest {
         int requestQuantity = inventoryQuantity - lastUpdatedQuantity + 10;
         assertThatThrownBy(() -> inventoryProductServiceImpl.updateShippedInventoryProductById(productId, id, requestQuantity))
                 .isInstanceOf(InventoryShortageException.class)
-                .hasMessage("Inventory shortage, only " + inventoryQuantity + " items left");
+                .hasMessage("Inventory shortage, only " + (inventoryQuantity - lastUpdatedQuantity) + " items left");
 
     }
 }


### PR DESCRIPTION
# 概要
在庫ID、商品ID、数量を指定して、出庫として数量を修正する機能を実装しました。
この機能を使うシーンとしては、在庫の誤登録の修正、を想定しています。
通常の出庫処理と異なる点は、修正対象の在庫が、最後に登録された在庫かどうか（同商品ID内）をチェックする点です。（理由は #53 に記載）

### updateShippedInventoryProductByIdの概要
引数に商品ID```productId```、在庫ID```id```、数量```quantity```を持ちます。
以下のチェックを行い、例外を投げます。
1. 指定した商品IDが存在しなければ```ResourceNotFoundException```を投げます
2. 指定した商品IDが論理削除済みであれば〃例外を投げます
3. 商品は存在し、在庫が存在しない（未登録）であれば〃例外を投げます
4. 在庫IDが、最後に登録された在庫でなければ```InvalidInputException```を投げます
5. 指定した数量がゼロ個以下であれば〃例外を投げます。
6. 指定した数量が【在庫数 - 直前の登録数】より大きければ```InventoryShortageException```を投げます

上記チェックで該当しなければ、数量にマイナスを掛け、マッパーに在庫IDと数量を渡します。

* 実装
46e646489309e4ed3c029e76125f540de833ef0d
* テスト
8599254db28159979056de49594a9ff856f05e48
* 在庫計算ロジック修正
641d395f0ce4872a8b03dadf08b59c5b208cdd8c
a69027483714b237f20ecb13908545714dbb3d30