### PR TITLE
IP.Controller/出庫修正処理

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/controller/InventoryProductController.java
+++ b/src/main/java/com/raisetech/inventoryapi/controller/InventoryProductController.java
@@ -63,4 +63,13 @@ public class InventoryProductController {
         return ResponseEntity.ok(Map.of("message", "Quantity was successfully updated"));
 
     }
+
+    @PatchMapping("/inventory-products/shipped-items/{id}")
+    public ResponseEntity<Map<String, String>> updateShippedInventoryProductById
+            (@RequestBody @Validated UpdateInventoryProductForm form,
+             @PathVariable(value = "id") int id) throws Exception {
+        InventoryProduct entity = form.convertToInventoryProductEntity();
+        inventoryProductService.updateShippedInventoryProductById(entity.getProductId(), id, entity.getQuantity());
+        return ResponseEntity.ok(Map.of("message", "Quantity was successfully updated"));
+    }
 }

--- a/src/test/resources/dataset/expectedUpdatedShippedInventoryProducts.yml
+++ b/src/test/resources/dataset/expectedUpdatedShippedInventoryProducts.yml
@@ -1,0 +1,17 @@
+inventoryProducts:
+  - id: 1
+    product_id: 1
+    quantity: 100
+    history: '2023-12-10 23:58:10'
+  - id: 2
+    product_id: 2
+    quantity: 200
+    history: '2024-1-10 12:58:10'
+  - id: 3
+    product_id: 3
+    quantity: 500
+    history: '2024-5-10 12:58:10'
+  - id: 4
+    product_id: 3
+    quantity: -100
+    history: '2024-5-11 12:58:10'


### PR DESCRIPTION
# 概要
コントローラークラスで出庫修正処理を実装しました。HTTPリクエスト```PATCH```でパス変数に最新の登録在庫ID```id```を指定し、商品ID```productId```と出庫として修正したい数量```quantity```を渡します。フォームで受け取り、（フォーム内のバリデーションチェックで問題なければ、）サービスへ渡し、処理成功のメッセージを返します。

* 実装
686e4508e6724f75420015e5d23119cea9a628c2
* テスト
8949668e7137407e227b1ebe559c7896f27c6c2d

### 実行結果（正常処理時）
#### InventoryProductsの登録状況
```productId : 5```の在庫合計数は```300```
```id : 6```の数量は```200```
![image](https://github.com/user-attachments/assets/d22615f5-5b7e-472a-b1ea-1442f23557be)
<br>

#### 出庫修正
```id : 6```の数量を```-50```へ、更新が正常に行われたことのメッセージが返る

![image](https://github.com/user-attachments/assets/031264a0-238f-4853-bbff-80f9611bf802)
<br>

#### InventoryProductsの登録状況（出庫修正後）
```id : 6```の数量は```-50```となった

![image](https://github.com/user-attachments/assets/1c9e6a67-2762-40ec-bf37-b29f3229f887)
<br>
<br>

### 実行結果（非正常処理時 ※新規性のある「修正対象の数量を除いた在庫数よりも出庫修正が多いかのチェック」部分のみ）

#### InventoryProductsの登録状況
```productId : 5```の在庫合計数は```300```
```id : 6```の数量は```200```

![image](https://github.com/user-attachments/assets/db927455-e297-4f65-8f32-7dbbdae03411)
<br>

#### 出庫修正
```id : 6```の数量を```-250```へ修正するリクエストを実施
在庫が100個しかなく、不足する旨メッセージが返る
※```productId : 5```の在庫合計数```300```に対し、修正対象```id : 6```の数量を```+200```から```-250```に変更することになるため、変更できてしまうと、```productId : 5```の在庫合計数は```-150```になってしまう

![image](https://github.com/user-attachments/assets/cb37212e-712a-4c33-af28-075a5fc7c5a1)
