### PR TITLE
openapi/在庫取得by在庫ID 仕様変更

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -241,38 +241,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/400BadRequest'
-  /inventory-products/{productId}:
-    get:
-      tags:
-        - InventoryProducts
-      summary: 商品IDによる在庫情報の取得
-      operationId: getInventoryItemsByProductId
-      description: |
-        指定した商品IDと一致する在庫情報を取得する
-      parameters:
-        - name: productId
-          in: path
-          required: true
-          schema:
-            type: integer
-          example: 1
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/InventoryProducts'
-        '404':
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/404NotFound'
   /inventory-products/received-items/{id}:
     patch:
       tags:
@@ -384,6 +352,37 @@ paths:
                     - $ref: '#/components/schemas/409ConflictOfUpdateShippedInventoryProduct'
                     - $ref: '#/components/schemas/409ConflictOfShippingInventoryProduct'
   /inventory-products/{id}:
+    get:
+      tags:
+        - InventoryProducts
+      summary: 在庫IDによる在庫情報の取得
+      operationId: getInventoryItemsById
+      description: |
+        指定した在庫IDと一致する在庫情報を取得する
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          example: 1
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/InventoryProducts'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/404InventoryProduct'
     delete:
       tags:
         - InventoryProducts


### PR DESCRIPTION
# 概要
商品ID```productId```による在庫取得を在庫ID```id```による取得へ変更しました。
理由は、
![image](https://github.com/user-attachments/assets/d8f07863-eaef-4a37-a16a-5c27c24f0205)
と機能が被っている点、および在庫IDを指定して検索する機能が無い点、があります。

### 変更点
各```productId```を```id```へ変更し、エンドポイントも以下のように変更しました。
変更前：```/inventory-products/{productId}```
変更後：```/inventory-products/{id}```