### PR TITLE
IP.Mapper/在庫IDによる在庫情報の取得処理

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/mapper/InventoryProductMapper.java
+++ b/src/main/java/com/raisetech/inventoryapi/mapper/InventoryProductMapper.java
@@ -23,4 +23,7 @@ public interface InventoryProductMapper {
 
     @Update("UPDATE inventoryProducts SET quantity = #{quantity} WHERE id =#{id}")
     void updateInventoryProductById(int id, int quantity);
+
+    @Select("SELECT * FROM inventoryProducts where id = #{id}")
+    Optional<InventoryProduct> findInventoryById(int id);
 }

--- a/src/test/java/com/raisetech/inventoryapi/mapper/InventoryProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/mapper/InventoryProductMapperTest.java
@@ -159,4 +159,24 @@ class InventoryProductMapperTest {
         inventoryProductMapper.updateInventoryProductById(id, quantity);
     }
 
+    @Test
+    @Transactional
+    void 指定したIDで在庫情報が取得できること() {
+        int id = 1;
+        Optional<InventoryProduct> inventoryProduct = inventoryProductMapper.findInventoryById(id);
+
+        OffsetDateTime offsetDateTime = OffsetDateTime.parse("2023-12-10T23:58:10+09:00");
+        assertThat(inventoryProduct).contains(new InventoryProduct(id, 1, 100, offsetDateTime));
+    }
+
+    @Test
+    @Transactional
+    void 存在しないIDで在庫情報取得時に空を返すこと() {
+        int id = 0;
+        Optional<InventoryProduct> inventoryProduct = inventoryProductMapper.findInventoryById(id);
+
+        Assertions.assertNotNull(inventoryProduct);
+        assertThat(inventoryProduct).isEmpty();
+    }
+
 }


### PR DESCRIPTION
# 概要
マッパーにて、指定した在庫ID```id```による在庫取得処理を実装しました。

### findInventoryByIdの概要
在庫IDを引数にもち、一致するレコードを```inventoryProducts```テーブルから取得し返します。一致する在庫IDが無い場合は、Optionalを使用し、空を返します。

* 実装
81a7ff09fd298d5f95015b90d974a91850dda805
* テスト
4ef0d9af0e8542f686ccbdf2b65b3e3769eb173f