### PR TITLE
IP.Controller/不要メソッドの削除

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/controller/InventoryProductController.java
+++ b/src/main/java/com/raisetech/inventoryapi/controller/InventoryProductController.java
@@ -22,14 +22,6 @@ public class InventoryProductController {
         this.inventoryProductService = inventoryProductService;
     }
 
-    @GetMapping("/inventory-products/{product_id}")
-    public Map<String, Integer> getQuantityByProductId(
-            @PathVariable(value = "product_id")
-            int product_id) {
-        Integer quantity = inventoryProductService.getQuantityByProductId(product_id);
-        return Map.of("quantity", quantity);
-    }
-
     @PostMapping("/inventory-products/received-items")
     public ResponseEntity<Map<String, String>> receivingInventoryProduct
             (@RequestBody @Validated CreateInventoryProductForm from, UriComponentsBuilder uriComponentsBuilder) {


### PR DESCRIPTION
# 概要
API仕様書に則り、```getQuantityByProductId```メソッドをコントローラークラスから削除しました。本メソッドはサービス、マッパーでは引き続き他のメソッドでも使用しており、現状維持です。コントローラーに実装していた理由は、挙動確認をしたかったため仮で実装していましたが、削除漏れしていました。また、今後実装予定の在庫削除処理のエンドポイント```/inventory-products/{id}```が被ってしまう点もあります。

bbd4a6f1180391d050d7f4c17852af2836c8c076

API仕様書
https://kumagai6824.github.io/Inventory-API/swagger/