### PR TITLE
IP.Mapper/在庫削除処理

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/mapper/InventoryProductMapper.java
+++ b/src/main/java/com/raisetech/inventoryapi/mapper/InventoryProductMapper.java
@@ -26,4 +26,7 @@ public interface InventoryProductMapper {
 
     @Select("SELECT * FROM inventoryProducts where id = #{id}")
     Optional<InventoryProduct> findInventoryById(int id);
+
+    @Delete("DELETE FROM inventoryProducts where id = #{id}")
+    void deleteInventoryById(int id);
 }

--- a/src/test/java/com/raisetech/inventoryapi/mapper/InventoryProductMapperTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/mapper/InventoryProductMapperTest.java
@@ -179,4 +179,21 @@ class InventoryProductMapperTest {
         assertThat(inventoryProduct).isEmpty();
     }
 
+    @Test
+    @ExpectedDataSet(value = "/dataset/expectedDeletedInventoryProducts.yml")
+    @Transactional
+    void 指定したIDの在庫情報が削除されること() {
+        int id = 1;
+        inventoryProductMapper.deleteInventoryById(id);
+    }
+
+    @Test
+    @ExpectedDataSet(value = "/inventoryProducts.yml")
+    @Transactional
+    void 存在しないIDで在庫削除時にinventoryProductsテーブルに変化が無いこと() {
+        int id = 0;
+        inventoryProductMapper.deleteInventoryById(id);
+    }
+
+
 }


### PR DESCRIPTION
# 概要
マッパーにて指定した在庫ID```id```を削除する処理を実装しました。

### deleteInventoryByIdの概要
```int id```を引数にもち、一致するidの在庫を```inventoryProducts```テーブルから削除します。

* 実装
e95c6e21a4619060aa5b4bd8ec4d855de66cc2ca
* テスト
381c15e392e6b7aca2de7cfe176ae333081055fd