### PR TITLE
IP.Service/在庫削除処理

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/service/InventoryProductService.java
+++ b/src/main/java/com/raisetech/inventoryapi/service/InventoryProductService.java
@@ -14,4 +14,6 @@ public interface InventoryProductService {
     void updateShippedInventoryProductById(int productId, int id, int quantity);
 
     InventoryProduct findInventoryById(int id) throws Exception;
+
+    void deleteInventoryById(int id);
 }

--- a/src/main/java/com/raisetech/inventoryapi/service/InventoryProductServiceImpl.java
+++ b/src/main/java/com/raisetech/inventoryapi/service/InventoryProductServiceImpl.java
@@ -124,5 +124,20 @@ public class InventoryProductServiceImpl implements InventoryProductService {
         return inventoryProduct;
     }
 
+    @Override
+    public void deleteInventoryById(int id) {
+        InventoryProduct inventoryProduct = inventoryProductMapper.findInventoryById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("ID:" + id + " does not exist"));
+
+        InventoryProduct latestInventoryProduct = inventoryProductMapper.findLatestInventoryByProductId(inventoryProduct.getProductId())
+                .orElseThrow(() -> new ResourceNotFoundException("Inventory item does not exist"));
+
+        if (latestInventoryProduct.getId() != id) {
+            throw new InventoryNotLatestException("Cannot update id: " + id + ", Only the last update can be altered.");
+        }
+
+        inventoryProductMapper.deleteInventoryById(id);
+    }
+
 
 }


### PR DESCRIPTION
# 概要
サービスにて指定した在庫ID```id```を削除する処理を実装しました。

### deleteInventoryByIdの概要
```int id```を引数にもち、以下のチェックを行い例外をスローします。
1. 在庫IDが存在しない場合は```ResourceNotFoundException```をスロー
2. 最新の在庫取得時に在庫が未登録の場合は```ResourceNotFoundException```をスロー　※（1 で在庫存在有無をチェックするため、異常な処理が起きなければ、2 はスローされることはない想定ですが、最新在庫取得メソッド自体は例外チェックが必要なためOptionalで実装されている）
3. 最新の在庫IDと、渡された```id```が一致しない場合```InventoryNotLatestException```をスロー

上記チェックに該当しなければマッパーへ```id```を渡します。

* 実装
3570ba799599e9be261b1d80983007826268220b
* テスト
3c46444365df9d1a67be9f0e2c9ad2d81c097de9

※以前、```@ParameterizedTest```の活用のアドバイスいただきました。初回テスト実装での活用は、頭が混乱しそうなので、一旦@Testでテストケースの洗い出ししてから、活用できそうな部分へ適用したいと思います！