### PR TITLE
IP.Controller/在庫削除処理

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/controller/InventoryProductController.java
+++ b/src/main/java/com/raisetech/inventoryapi/controller/InventoryProductController.java
@@ -69,4 +69,11 @@ public class InventoryProductController {
     public InventoryProduct findInventoryById(@PathVariable(value = "id") int id) throws Exception {
         return inventoryProductService.findInventoryById(id);
     }
+
+    @DeleteMapping("/inventory-products/{id}")
+    public ResponseEntity<Map<String, String>> deleteInventoryById
+            (@PathVariable(value = "id") int id) throws Exception {
+        inventoryProductService.deleteInventoryById(id);
+        return ResponseEntity.ok(Map.of("message", "Successful operation"));
+    }
 }


### PR DESCRIPTION
# 概要
コントローラーにて指定した在庫IDで在庫を削除する処理を追加しました。

### deleteInventoryByIdの概要
エンドポイント：```HTTPリクエスト DELETE  /inventory-products/{id}```

パス変数の```id```を引数```int id```として受け取り、サービスへ渡します。サービスで例外がスローされずに正常に削除処理が進めば、処理成功のメッセージを返します。

* 実装
1a7c9145682e432ebe38f61bc4a2393203879c26
* テスト
ace4613e49d78b5438d412e6531db11fce4c2335

### 実行結果（正常処理時）
#### inventoryProductsの登録状況
```商品id : 5 ``` の在庫は、 ```在庫id : 7```が最新
![image](https://github.com/user-attachments/assets/d5b2aa19-eeda-488e-8635-4448c3baf8ce)

#### 在庫削除
```在庫id : 7 ```を削除、削除処理が正常に行われたことのメッセージが返る。
![image](https://github.com/user-attachments/assets/5c291e66-b6b8-4903-ac4e-4a35a58089f9)

### 実行結果（非正常処理時 ※「最後に登録された在庫かどうかのチェック」部分のみ）
#### inventoryProductsの登録状況
```商品id : 5 ``` の在庫は、 ```在庫id : 8```が最新
![image](https://github.com/user-attachments/assets/420869d2-fcab-459b-b152-4c0d6716a0d6)

#### 在庫削除
```在庫id : 5 ```を削除、最後に登録された在庫でないため、削除できないメッセージを返す。
![image](https://github.com/user-attachments/assets/0523ba01-c5f6-4371-8089-1284aace8260)
