### PR TITLE
openapi/現在庫数取得 仕様追加

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -216,14 +216,14 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/404NotFound'
-  /inventory-products:
+  /inventory-products/current-inventories:
     get:
       tags:
         - InventoryProducts
-      summary: 在庫情報の取得
-      operationId: getInventoryItems
+      summary: 現在庫数の全件取得
+      operationId: getCurrentInventories
       description: |
-        すべての在庫情報を取得する
+        すべての商品の現在庫数を取得する
       responses:
         '200':
           description: OK
@@ -232,15 +232,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/InventoryProducts'
-        '400':
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/400BadRequest'
+                  $ref: '#/components/schemas/CurrentInventories'
   /inventory-products/received-items/{id}:
     patch:
       tags:
@@ -547,6 +539,22 @@ components:
           type: string
           example: '2024-05-10T23:59:59+09:00'
           format: date-time
+    CurrentInventories:
+      type: object
+      required:
+        - productId
+        - name
+        - quantity
+      properties:
+        productId:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: 'Bolt 1'
+        quantity:
+          type: integer
+          example: 1000
     InventoryProducts:
       type: object
       required:


### PR DESCRIPTION
# 概要
「在庫情報の取得」を削除し、「現在庫数の取得」を追加しました。

理由は以下です。
* 「在庫情報」は```在庫IDによる在庫情報の取得```や```商品IDによる在庫履歴の全件取得```で確認できる
* 「現在庫数」を確認できる機能が無い

### 変更点
エンドポイントを以下に変更しました。
変更前：```/inventory-products```
変更後：```/inventory-products/current-inventories```　「在庫カテゴリーにおいての現在庫数」旨の表現

非正常時として在庫や商品が未登録の場合は、空が返される想定をしています。

### API仕様、最終課題においての位置づけ
今回「在庫情報の取得」を削除しましたが、本来は全件取得機能として見た時には求められる機能だと認識しています。一方で既に複数の機能を実装済みで、最終課題としては同機能は無くても差し支えないと考えました。
「現在庫数の取得」を実装後は、コード、ドキュメントの整理とデプロイへの準備を進めたいと考えています。

API仕様書リンク（今後の更新内容も反映される）
https://kumagai6824.github.io/Inventory-API/swagger/