### PR TITLE
IP.Service/現在庫数の全件取得

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/entity/CurrentInventory.java
+++ b/src/main/java/com/raisetech/inventoryapi/entity/CurrentInventory.java
@@ -1,0 +1,39 @@
+package com.raisetech.inventoryapi.entity;
+
+import java.util.Objects;
+
+public class CurrentInventory {
+    private int productId;
+    private String name;
+    private int quantity;
+
+    public CurrentInventory(int productId, String name, int quantity) {
+        this.productId = productId;
+        this.name = name;
+        this.quantity = quantity;
+    }
+
+    public int getProductId() {
+        return productId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CurrentInventory that)) return false;
+        return productId == that.productId && quantity == that.quantity && name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(productId, name, quantity);
+    }
+}

--- a/src/main/java/com/raisetech/inventoryapi/service/InventoryProductService.java
+++ b/src/main/java/com/raisetech/inventoryapi/service/InventoryProductService.java
@@ -1,6 +1,9 @@
 package com.raisetech.inventoryapi.service;
 
+import com.raisetech.inventoryapi.entity.CurrentInventory;
 import com.raisetech.inventoryapi.entity.InventoryProduct;
+
+import java.util.List;
 
 public interface InventoryProductService {
     Integer getQuantityByProductId(int productId);
@@ -16,4 +19,6 @@ public interface InventoryProductService {
     InventoryProduct findInventoryById(int id) throws Exception;
 
     void deleteInventoryById(int id);
+
+    List<CurrentInventory> getCurrentInventories();
 }

--- a/src/main/java/com/raisetech/inventoryapi/service/InventoryProductServiceImpl.java
+++ b/src/main/java/com/raisetech/inventoryapi/service/InventoryProductServiceImpl.java
@@ -1,5 +1,6 @@
 package com.raisetech.inventoryapi.service;
 
+import com.raisetech.inventoryapi.entity.CurrentInventory;
 import com.raisetech.inventoryapi.entity.InventoryProduct;
 import com.raisetech.inventoryapi.entity.Product;
 import com.raisetech.inventoryapi.exception.InvalidInputException;
@@ -10,7 +11,9 @@ import com.raisetech.inventoryapi.mapper.InventoryProductMapper;
 import com.raisetech.inventoryapi.mapper.ProductMapper;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 public class InventoryProductServiceImpl implements InventoryProductService {
@@ -139,5 +142,19 @@ public class InventoryProductServiceImpl implements InventoryProductService {
         inventoryProductMapper.deleteInventoryById(id);
     }
 
+    @Override
+    public List<CurrentInventory> getCurrentInventories() {
+        List<Product> products = productMapper.findAll();
 
+        List<CurrentInventory> currentInventories = products.stream()
+                .map(product -> {
+                    int productId = product.getId();
+                    String name = product.getName();
+                    int quantity = inventoryProductMapper.getQuantityByProductId(productId);
+                    return new CurrentInventory(productId, name, quantity);
+                })
+                .collect(Collectors.toList());
+
+        return currentInventories;
+    }
 }


### PR DESCRIPTION
# 概要
サービスにて商品ごとの現在庫数を全件取得する処理を追加しました。

### CurrentInventory クラスの概要
現在庫情報として、商品ID```productId```、商品名```name```、在庫数```quantity```をフィールドに持ちます。

### getCurrentInventories の概要
商品の全件取得```findAll( )```で商品のリストを取得します。現在庫用のエンティティ```CurrentInventory```のインスタンスを生成し、取得済みの商品ID、商品名、在庫数を渡します。```List<CurrentInventory>```で返します。在庫数は```getQuantityByProductId```を利用しています。

### 論理削除済み品の扱い
商品は論理削除されると、```deleted_at```カラムに論理削除処理日時が代入されます。今回使っている、商品の全件取得```findAll( )```はマッパークラスで```where deleted_at IS NULL```に該当するレコード（＝論理削除されていないレコード）を取得しているため、論理削除済み品は扱われません。

* 実装
5279fffb5adb5dc36abce30c9631136a8960326c
8efd6fee861b08168156b74d80b7212a5cba8c02
* テスト
efa378829e7b4f6879ec56f473eee87f33dee751