### PR TITLE
IP.Controller/現在庫数の全件取得

### DIFF
--- a/src/main/java/com/raisetech/inventoryapi/controller/InventoryProductController.java
+++ b/src/main/java/com/raisetech/inventoryapi/controller/InventoryProductController.java
@@ -1,5 +1,6 @@
 package com.raisetech.inventoryapi.controller;
 
+import com.raisetech.inventoryapi.entity.CurrentInventory;
 import com.raisetech.inventoryapi.entity.InventoryProduct;
 import com.raisetech.inventoryapi.form.CreateInventoryProductForm;
 import com.raisetech.inventoryapi.form.UpdateInventoryProductForm;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -75,5 +77,10 @@ public class InventoryProductController {
             (@PathVariable(value = "id") int id) throws Exception {
         inventoryProductService.deleteInventoryById(id);
         return ResponseEntity.ok(Map.of("message", "Successful operation"));
+    }
+
+    @GetMapping("/inventory-products/current-inventories")
+    public List<CurrentInventory> getCurrentInventories() {
+        return inventoryProductService.getCurrentInventories();
     }
 }

--- a/src/main/java/com/raisetech/inventoryapi/controller/InventoryProductController.java
+++ b/src/main/java/com/raisetech/inventoryapi/controller/InventoryProductController.java
@@ -1,6 +1,6 @@
 package com.raisetech.inventoryapi.controller;
 
-import com.raisetech.inventoryapi.entity.CurrentInventory;
+import com.raisetech.inventoryapi.entity.Inventory;
 import com.raisetech.inventoryapi.entity.InventoryProduct;
 import com.raisetech.inventoryapi.form.CreateInventoryProductForm;
 import com.raisetech.inventoryapi.form.UpdateInventoryProductForm;
@@ -80,7 +80,7 @@ public class InventoryProductController {
     }
 
     @GetMapping("/inventory-products/current-inventories")
-    public List<CurrentInventory> getCurrentInventories() {
+    public List<Inventory> getCurrentInventories() {
         return inventoryProductService.getCurrentInventories();
     }
 }

--- a/src/main/java/com/raisetech/inventoryapi/entity/Inventory.java
+++ b/src/main/java/com/raisetech/inventoryapi/entity/Inventory.java
@@ -2,12 +2,12 @@ package com.raisetech.inventoryapi.entity;
 
 import java.util.Objects;
 
-public class CurrentInventory {
+public class Inventory {
     private int productId;
     private String name;
     private int quantity;
 
-    public CurrentInventory(int productId, String name, int quantity) {
+    public Inventory(int productId, String name, int quantity) {
         this.productId = productId;
         this.name = name;
         this.quantity = quantity;
@@ -28,7 +28,7 @@ public class CurrentInventory {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof CurrentInventory that)) return false;
+        if (!(o instanceof Inventory that)) return false;
         return productId == that.productId && quantity == that.quantity && name.equals(that.name);
     }
 

--- a/src/main/java/com/raisetech/inventoryapi/service/InventoryProductService.java
+++ b/src/main/java/com/raisetech/inventoryapi/service/InventoryProductService.java
@@ -1,6 +1,6 @@
 package com.raisetech.inventoryapi.service;
 
-import com.raisetech.inventoryapi.entity.CurrentInventory;
+import com.raisetech.inventoryapi.entity.Inventory;
 import com.raisetech.inventoryapi.entity.InventoryProduct;
 
 import java.util.List;
@@ -20,5 +20,5 @@ public interface InventoryProductService {
 
     void deleteInventoryById(int id);
 
-    List<CurrentInventory> getCurrentInventories();
+    List<Inventory> getCurrentInventories();
 }

--- a/src/main/java/com/raisetech/inventoryapi/service/InventoryProductServiceImpl.java
+++ b/src/main/java/com/raisetech/inventoryapi/service/InventoryProductServiceImpl.java
@@ -1,6 +1,6 @@
 package com.raisetech.inventoryapi.service;
 
-import com.raisetech.inventoryapi.entity.CurrentInventory;
+import com.raisetech.inventoryapi.entity.Inventory;
 import com.raisetech.inventoryapi.entity.InventoryProduct;
 import com.raisetech.inventoryapi.entity.Product;
 import com.raisetech.inventoryapi.exception.InvalidInputException;
@@ -143,15 +143,15 @@ public class InventoryProductServiceImpl implements InventoryProductService {
     }
 
     @Override
-    public List<CurrentInventory> getCurrentInventories() {
+    public List<Inventory> getCurrentInventories() {
         List<Product> products = productMapper.findAll();
 
-        List<CurrentInventory> currentInventories = products.stream()
+        List<Inventory> currentInventories = products.stream()
                 .map(product -> {
                     int productId = product.getId();
                     String name = product.getName();
                     int quantity = inventoryProductMapper.getQuantityByProductId(productId);
-                    return new CurrentInventory(productId, name, quantity);
+                    return new Inventory(productId, name, quantity);
                 })
                 .collect(Collectors.toList());
 

--- a/src/test/java/com/raisetech/inventoryapi/service/InventoryProductServiceImplTest.java
+++ b/src/test/java/com/raisetech/inventoryapi/service/InventoryProductServiceImplTest.java
@@ -1,6 +1,6 @@
 package com.raisetech.inventoryapi.service;
 
-import com.raisetech.inventoryapi.entity.CurrentInventory;
+import com.raisetech.inventoryapi.entity.Inventory;
 import com.raisetech.inventoryapi.entity.InventoryProduct;
 import com.raisetech.inventoryapi.entity.Product;
 import com.raisetech.inventoryapi.exception.InvalidInputException;
@@ -478,12 +478,12 @@ class InventoryProductServiceImplTest {
         doReturn(100).when(inventoryProductMapper).getQuantityByProductId(1);
         doReturn(500).when(inventoryProductMapper).getQuantityByProductId(2);
 
-        List<CurrentInventory> expectedCurrentInventories = new ArrayList<CurrentInventory>(Arrays.asList(
-                new CurrentInventory(1, "test", 100),
-                new CurrentInventory(2, "test2", 500)
+        List<Inventory> expectedCurrentInventories = new ArrayList<Inventory>(Arrays.asList(
+                new Inventory(1, "test", 100),
+                new Inventory(2, "test2", 500)
         ));
 
-        List<CurrentInventory> actualCurrentInventories = inventoryProductServiceImpl.getCurrentInventories();
+        List<Inventory> actualCurrentInventories = inventoryProductServiceImpl.getCurrentInventories();
 
         assertThat(actualCurrentInventories).isEqualTo(expectedCurrentInventories);
     }
@@ -498,12 +498,12 @@ class InventoryProductServiceImplTest {
         doReturn(0).when(inventoryProductMapper).getQuantityByProductId(1);
         doReturn(0).when(inventoryProductMapper).getQuantityByProductId(2);
 
-        List<CurrentInventory> expectedCurrentInventories = new ArrayList<CurrentInventory>(Arrays.asList(
-                new CurrentInventory(1, "test", 0),
-                new CurrentInventory(2, "test2", 0)
+        List<Inventory> expectedCurrentInventories = new ArrayList<Inventory>(Arrays.asList(
+                new Inventory(1, "test", 0),
+                new Inventory(2, "test2", 0)
         ));
 
-        List<CurrentInventory> actualCurrentInventories = inventoryProductServiceImpl.getCurrentInventories();
+        List<Inventory> actualCurrentInventories = inventoryProductServiceImpl.getCurrentInventories();
 
         assertThat(actualCurrentInventories).isEqualTo(expectedCurrentInventories);
     }
@@ -512,7 +512,7 @@ class InventoryProductServiceImplTest {
     public void 現在庫数を取得時に商品が存在しないとき空を返すこと() {
         doReturn(List.of()).when(productMapper).findAll();
 
-        List<CurrentInventory> actualCurrentInventories = inventoryProductServiceImpl.getCurrentInventories();
+        List<Inventory> actualCurrentInventories = inventoryProductServiceImpl.getCurrentInventories();
 
         assertThat(actualCurrentInventories).isEqualTo(List.of());
     }

--- a/src/test/java/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/UserRestApiIntegrationTest.java
@@ -1013,4 +1013,52 @@ public class UserRestApiIntegrationTest {
         assertEquals("Conflict", JsonPath.read(response, "$.error"));
         assertEquals("Cannot update id: " + id + ", Only the last update can be altered.", JsonPath.read(response, "$.message"));
     }
+
+    @Test
+    @Transactional
+    void 現在庫数を全件取得出来ること() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/inventory-products/current-inventories"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                         [
+                            {
+                               "productId":1,
+                               "name":"Bolt 1",
+                               "quantity":100
+                            },
+                            {
+                               "productId":2,
+                               "name":"Washer",
+                               "quantity":200
+                            },
+                            {
+                               "productId":3,
+                               "name":"Gear",
+                               "quantity":0
+                            },
+                            {
+                               "productId":4,
+                               "name":"Shaft",
+                               "quantity":0
+                            }
+                         ]
+                        """
+                , response, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    @DataSet(value = "empty-products.yml")
+    @Transactional
+    void 現在庫数を全件取得時に商品が存在しないとき空を返すこと() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/inventory-products/current-inventories"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                         []
+                        """
+                , response, JSONCompareMode.STRICT);
+    }
 }


### PR DESCRIPTION
# 概要
コントローラークラスにて商品ごとの現在庫数を取得する処理を実装しました。

### getCurrentInventoriesの概要
エンドポイント：```HTTPリクエストGET  /inventory-products/current-inventories```
処理をリクエストすると、サービスの現在庫数取得処理を呼び出します。商品ごとの現在庫数```List<CurrentInventory>```を返します。

* 実装
d411fa20c677d5a4673da98d354f46f601107717
* テスト
698c12ac837a5866067ac6047f4b8ee454d1ba70

### 実行結果（正常処理時）
#### inventoryProductsの状況
```商品id : 5 ```の在庫は、```500個```と```-100個```
![image](https://github.com/user-attachments/assets/a0d96f12-f0ee-48bf-8dc0-041d75871e30)

#### 現在庫数の取得
在庫数として```400個```がquantityに入っている
![image](https://github.com/user-attachments/assets/c4a43d2e-061f-463f-a4d9-ce0691c7f776)


### 実行結果（商品が存在しない場合）
#### productsの状況
未登録で空の状態
![image](https://github.com/user-attachments/assets/b5955162-a92a-4e31-bc5e-3f8cd4b1cf0f)

#### 現在庫数の取得
空が返る
![image](https://github.com/user-attachments/assets/3bd819d4-1e26-42a2-b887-fd48226f7608)
